### PR TITLE
Fix: admin bech32, NIGHT labels, loan USD units, Set PIN feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2313,88 +2313,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot-api/json-rpc-provider": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
-      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
-      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
-      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.6.0",
-        "@polkadot-api/utils": "0.1.0"
-      }
-    },
-    "node_modules/@polkadot-api/observable-client": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
-      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@polkadot-api/metadata-builders": "0.3.2",
-        "@polkadot-api/substrate-bindings": "0.6.0",
-        "@polkadot-api/utils": "0.1.0"
-      },
-      "peerDependencies": {
-        "@polkadot-api/substrate-client": "0.1.4",
-        "rxjs": ">=7.8.0"
-      }
-    },
-    "node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
-      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@noble/hashes": "^1.3.1",
-        "@polkadot-api/utils": "0.1.0",
-        "@scure/base": "^1.1.1",
-        "scale-ts": "^1.6.0"
-      }
-    },
-    "node_modules/@polkadot-api/substrate-bindings/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot-api/substrate-client": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
-      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.1",
-        "@polkadot-api/utils": "0.1.0"
-      }
-    },
-    "node_modules/@polkadot-api/utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
-      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@polkadot/api": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
@@ -3533,56 +3451,6 @@
         "@subsquid/util-internal-hex": "^1.2.2"
       }
     },
-    "node_modules/@substrate/connect": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
-      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
-      "deprecated": "versions below 1.x are no longer maintained",
-      "license": "GPL-3.0-only",
-      "optional": true,
-      "dependencies": {
-        "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.5",
-        "@substrate/light-client-extension-helpers": "^1.0.0",
-        "smoldot": "2.0.26"
-      }
-    },
-    "node_modules/@substrate/connect-extension-protocol": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.2.tgz",
-      "integrity": "sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==",
-      "license": "GPL-3.0-only",
-      "optional": true
-    },
-    "node_modules/@substrate/connect-known-chains": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.10.3.tgz",
-      "integrity": "sha512-OJEZO1Pagtb6bNE3wCikc2wrmvEU5x7GxFFLqqbz1AJYYxSlrPCGu4N2og5YTExo4IcloNMQYFRkBGue0BKZ4w==",
-      "license": "GPL-3.0-only",
-      "optional": true
-    },
-    "node_modules/@substrate/connect/node_modules/smoldot": {
-      "optional": true
-    },
-    "node_modules/@substrate/light-client-extension-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
-      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@polkadot-api/json-rpc-provider": "^0.0.1",
-        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
-        "@polkadot-api/observable-client": "^0.3.0",
-        "@polkadot-api/substrate-client": "^0.1.2",
-        "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.5",
-        "rxjs": "^7.8.1"
-      },
-      "peerDependencies": {
-        "smoldot": "2.x"
-      }
-    },
     "node_modules/@substrate/ss58-registry": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.51.0.tgz",
@@ -3641,6 +3509,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3658,6 +3527,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3675,6 +3545,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3692,6 +3563,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3709,6 +3581,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3726,6 +3599,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3743,6 +3617,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3760,6 +3635,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3777,6 +3653,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3794,6 +3671,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10180,13 +10058,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/scale-ts": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
-      "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -10444,10 +10315,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/smoldot": {
-      "optional": true,
-      "peer": true
     },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
@@ -11174,6 +11041,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11920,6 +11920,7 @@
         "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.0.4",
         "@midnight-ntwrk/midnight-js-network-id": "4.0.4",
         "@midnight-ntwrk/midnight-js-types": "4.0.4",
+        "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
         "@mui/icons-material": "^7.3.6",
         "@mui/material": "^7.3.6",
         "buffer": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.0.4",
         "@midnight-ntwrk/midnight-js-types": "4.0.4",
         "@midnight-ntwrk/midnight-js-utils": "4.0.4",
+        "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
         "@midnight-ntwrk/wallet-sdk-dust-wallet": "3.0.0",
         "@midnight-ntwrk/wallet-sdk-facade": "3.0.0",
         "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.0.4",
     "@midnight-ntwrk/midnight-js-types": "4.0.4",
     "@midnight-ntwrk/midnight-js-utils": "4.0.4",
+    "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
     "@midnight-ntwrk/wallet-sdk-dust-wallet": "3.0.0",
     "@midnight-ntwrk/wallet-sdk-facade": "3.0.0",
     "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",

--- a/zkloan-credit-scorer-cli/src/address-utils.ts
+++ b/zkloan-credit-scorer-cli/src/address-utils.ts
@@ -1,0 +1,81 @@
+// This file is part of the ZKLoan Credit Scorer example.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  MidnightBech32m,
+  ShieldedAddress,
+} from '@midnight-ntwrk/wallet-sdk-address-format';
+import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+
+/**
+ * Resolve a user-provided Zswap coin public key.
+ *
+ * Accepts either:
+ *   - a Midnight shielded address (bech32, e.g. `mn_shield-addr_preprod1…`
+ *     or `mn_shield-addr_undeployed1…`). The coin public key is extracted
+ *     from the address; the encryption key portion is discarded.
+ *   - a raw 32-byte hex string (64 hex chars, with or without `0x` prefix).
+ *
+ * The admin circuits (blacklistUser / removeBlacklistUser / transferAdmin)
+ * want a `ZswapCoinPublicKey` which is 32 bytes, so both inputs produce
+ * the same output.
+ *
+ * Throws with a clear message if the input is neither a valid bech32
+ * shielded address nor 32-byte hex.
+ */
+export function resolveZswapCoinPublicKey(input: string): Uint8Array {
+  const value = input.trim();
+  if (!value) {
+    throw new Error('No address provided.');
+  }
+
+  // Bech32 shielded address
+  if (value.startsWith('mn_shield-addr_')) {
+    let parsed: MidnightBech32m;
+    try {
+      parsed = MidnightBech32m.parse(value);
+    } catch (err) {
+      throw new Error(
+        `Invalid shielded address (bech32 parse failed): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    const networkId = getNetworkId();
+    try {
+      const shieldedAddress = parsed.decode(ShieldedAddress, networkId);
+      return new Uint8Array(shieldedAddress.coinPublicKey.data);
+    } catch (err) {
+      throw new Error(
+        `Could not decode shielded address for network '${String(networkId)}'. ` +
+        `Ensure the address prefix matches the active network. ` +
+        `Cause: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // Raw hex fallback
+  const hex = value.toLowerCase().replace(/^0x/, '');
+  if (!/^[0-9a-f]+$/.test(hex)) {
+    throw new Error(
+      'Unrecognised address format. Expected a shielded address (mn_shield-addr_…) ' +
+      'or a 32-byte hex string.',
+    );
+  }
+  if (hex.length !== 64) {
+    throw new Error(
+      `Hex public key must be exactly 64 hex chars (32 bytes); got ${hex.length}.`,
+    );
+  }
+  return Uint8Array.from(Buffer.from(hex, 'hex'));
+}

--- a/zkloan-credit-scorer-cli/src/api.ts
+++ b/zkloan-credit-scorer-cli/src/api.ts
@@ -206,7 +206,7 @@ export const requestLoan = async (
   logger.info(`Private state updated with attestation (provider ${providerInfo.providerId})`);
 
   // 6. Call the circuit
-  logger.info(`Requesting loan for amount: ${amountRequested} with PIN...`);
+  logger.info(`Requesting loan for $${amountRequested} (USD) with PIN...`);
   const finalizedTxData = await contract.callTx.requestLoan(amountRequested, secretPin);
   logger.info(`Transaction ${finalizedTxData.public.txId} added in block ${finalizedTxData.public.blockHeight}`);
   return finalizedTxData.public;
@@ -355,7 +355,7 @@ export const waitForFunds = (wallet: WalletFacade) =>
       Rx.tap((state) => {
         const unshielded = state.unshielded?.balances[ledger.nativeToken().raw] ?? 0n;
         const shielded = state.shielded?.balances[ledger.nativeToken().raw] ?? 0n;
-        logger.info(`Waiting for funds. Synced: ${state.isSynced}, Unshielded: ${unshielded}, Shielded: ${shielded}`);
+        logger.info(`Waiting for NIGHT funds. Synced: ${state.isSynced}, Unshielded: ${unshielded}, Shielded: ${shielded}`);
       }),
       Rx.filter((state) => state.isSynced),
       Rx.map((s) => (s.unshielded?.balances[ledger.nativeToken().raw] ?? 0n) + (s.shielded?.balances[ledger.nativeToken().raw] ?? 0n)),
@@ -364,19 +364,26 @@ export const waitForFunds = (wallet: WalletFacade) =>
   );
 
 /**
- * Display wallet balances (unshielded, shielded, total)
+ * Display wallet balances.
+ *
+ * On Midnight, NIGHT is the user-facing token and DUST is the fee resource
+ * generated from registered NIGHT UTXOs. Testnets use the prefixed
+ * tNIGHT / tDUST variants. We query the native token for NIGHT and the
+ * dust wallet for DUST and surface both so it's obvious which is which.
  */
-export const displayWalletBalances = async (wallet: WalletFacade): Promise<{ unshielded: bigint; shielded: bigint; total: bigint }> => {
+export const displayWalletBalances = async (wallet: WalletFacade): Promise<{ unshielded: bigint; shielded: bigint; total: bigint; dust: bigint }> => {
   const state = await Rx.firstValueFrom(wallet.state());
   const unshielded = state.unshielded?.balances[ledger.nativeToken().raw] ?? 0n;
   const shielded = state.shielded?.balances[ledger.nativeToken().raw] ?? 0n;
   const total = unshielded + shielded;
+  const dust = state.dust?.balance(new Date()) ?? 0n;
 
-  logger.info(`Unshielded balance: ${unshielded} tDUST`);
-  logger.info(`Shielded balance: ${shielded} tDUST`);
-  logger.info(`Total balance: ${total} tDUST`);
+  logger.info(`Unshielded NIGHT balance: ${unshielded}`);
+  logger.info(`Shielded NIGHT balance: ${shielded}`);
+  logger.info(`Total NIGHT balance: ${total}`);
+  logger.info(`DUST balance (for fees): ${dust}`);
 
-  return { unshielded, shielded, total };
+  return { unshielded, shielded, total, dust };
 };
 
 /**

--- a/zkloan-credit-scorer-cli/src/cli.ts
+++ b/zkloan-credit-scorer-cli/src/cli.ts
@@ -21,6 +21,7 @@ import { type ZKLoanCreditScorerProviders, type DeployedZKLoanCreditScorerContra
 import { type Config, StandaloneConfig } from './config';
 import * as api from './api';
 import type { WalletContext } from './api';
+import { resolveZswapCoinPublicKey } from './address-utils';
 import { getUserProfile } from './state.utils';
 import 'dotenv/config';
 
@@ -81,7 +82,9 @@ const requestLoan = async (
   walletContext: WalletContext,
   rli: Interface,
 ): Promise<void> => {
-  const amountStr = await rli.question('Enter the loan amount requested: ');
+  const amountStr = await rli.question(
+    'Enter the loan amount (USD, 1-65535 — the contract caps approvals at $10,000 / $7,000 / $3,000 per tier): ',
+  );
   const pinStr = await rli.question('Enter your secret PIN: ');
 
   const amount = BigInt(amountStr);
@@ -107,25 +110,28 @@ const changePinFlow = async (contract: DeployedZKLoanCreditScorerContract, rli: 
   logger.info('Note: If you have many loans, you may need to call this multiple times to complete the migration.');
 };
 
+const ADDRESS_PROMPT_HINT =
+  '(shielded address `mn_shield-addr_…` or 32-byte hex public key)';
+
 const blacklistUserFlow = async (contract: DeployedZKLoanCreditScorerContract, rli: Interface): Promise<void> => {
-  const accountHex = await rli.question('Enter the Zswap public key to blacklist (hex): ');
-  const account = Buffer.from(accountHex, 'hex');
+  const accountInput = await rli.question(`Enter the user to blacklist ${ADDRESS_PROMPT_HINT}: `);
+  const account = resolveZswapCoinPublicKey(accountInput);
 
   await api.blacklistUser(contract, account);
   logger.info('User blacklisted successfully!');
 };
 
 const removeBlacklistUserFlow = async (contract: DeployedZKLoanCreditScorerContract, rli: Interface): Promise<void> => {
-  const accountHex = await rli.question('Enter the Zswap public key to remove from blacklist (hex): ');
-  const account = Buffer.from(accountHex, 'hex');
+  const accountInput = await rli.question(`Enter the user to remove from blacklist ${ADDRESS_PROMPT_HINT}: `);
+  const account = resolveZswapCoinPublicKey(accountInput);
 
   await api.removeBlacklistUser(contract, account);
   logger.info('User removed from blacklist successfully!');
 };
 
 const transferAdminFlow = async (contract: DeployedZKLoanCreditScorerContract, rli: Interface): Promise<void> => {
-  const newAdminHex = await rli.question('Enter the new admin Zswap public key (hex): ');
-  const newAdmin = Buffer.from(newAdminHex, 'hex');
+  const newAdminInput = await rli.question(`Enter the new admin ${ADDRESS_PROMPT_HINT}: `);
+  const newAdmin = resolveZswapCoinPublicKey(newAdminInput);
 
   await api.transferAdmin(contract, newAdmin);
   logger.info('Admin role transferred successfully!');

--- a/zkloan-credit-scorer-ui/package.json
+++ b/zkloan-credit-scorer-ui/package.json
@@ -24,6 +24,7 @@
     "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.0.4",
     "@midnight-ntwrk/midnight-js-network-id": "4.0.4",
     "@midnight-ntwrk/midnight-js-types": "4.0.4",
+    "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
     "@mui/icons-material": "^7.3.6",
     "@mui/material": "^7.3.6",
     "buffer": "^6.0.3",

--- a/zkloan-credit-scorer-ui/src/components/PrivateStateCard.tsx
+++ b/zkloan-credit-scorer-ui/src/components/PrivateStateCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Card,
   CardContent,
@@ -11,6 +11,8 @@ import {
   TextField,
   Button,
   Stack,
+  Alert,
+  CircularProgress,
 } from '@mui/material';
 import { useZKLoanContext } from '../hooks';
 import { userProfiles } from '../utils/loanProfiles';
@@ -111,8 +113,14 @@ export const PrivateStateCard: React.FC = () => {
     secretPin,
     setSecretPin,
     refreshLoans,
+    changePin,
   } = useZKLoanContext();
   const [selectedProfile, setSelectedProfile] = React.useState(0);
+  const [savedPin, setSavedPin] = useState<string | null>(null);
+  const [showChangePin, setShowChangePin] = useState(false);
+  const [newPin, setNewPin] = useState('');
+  const [isChangingPin, setIsChangingPin] = useState(false);
+  const [pinMessage, setPinMessage] = useState<{ tone: 'success' | 'error' | 'info'; text: string } | null>(null);
 
   const currentProfile = userProfiles[selectedProfile];
   const tierInfo = evaluateTier(
@@ -141,13 +149,59 @@ export const PrivateStateCard: React.FC = () => {
   const handlePinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.replace(/\D/g, '').slice(0, 6);
     setSecretPin(value);
+    // Clear stale confirmation if the user is editing
+    if (savedPin !== null && value !== savedPin) {
+      setPinMessage(null);
+    }
   };
 
-  const handleLoadLoans = () => {
+  const handleNewPinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewPin(e.target.value.replace(/\D/g, '').slice(0, 6));
+  };
+
+  const handleSavePin = () => {
+    setSavedPin(secretPin);
+    setPinMessage({
+      tone: 'success',
+      text: 'PIN saved locally. It will be used to derive your identity when you request or respond to a loan.',
+    });
     refreshLoans();
   };
 
+  const handleChangePin = async () => {
+    if (!savedPin) return;
+    if (newPin === savedPin) {
+      setPinMessage({ tone: 'error', text: 'New PIN must differ from the current PIN.' });
+      return;
+    }
+    if (newPin.length < 4 || newPin.length > 6) {
+      setPinMessage({ tone: 'error', text: 'New PIN must be 4–6 digits.' });
+      return;
+    }
+    setIsChangingPin(true);
+    setPinMessage({ tone: 'info', text: 'Submitting on-chain PIN migration…' });
+    try {
+      await changePin(BigInt(savedPin), BigInt(newPin));
+      setSavedPin(newPin);
+      setNewPin('');
+      setShowChangePin(false);
+      setPinMessage({
+        tone: 'success',
+        text:
+          'PIN change submitted. On-chain migration moves up to 5 loans per call — if you had more, click Change PIN again to continue.',
+      });
+    } catch (err) {
+      setPinMessage({
+        tone: 'error',
+        text: `PIN change failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    } finally {
+      setIsChangingPin(false);
+    }
+  };
+
   const isPinValid = secretPin.length >= 4 && secretPin.length <= 6;
+  const isSaved = savedPin !== null && savedPin === secretPin;
 
   return (
     <Card>
@@ -215,14 +269,97 @@ export const PrivateStateCard: React.FC = () => {
           />
 
           <Button
-            variant="outlined"
-            onClick={handleLoadLoans}
-            disabled={!isPinValid}
+            variant={isSaved ? 'text' : 'outlined'}
+            onClick={handleSavePin}
+            disabled={!isPinValid || isSaved}
             sx={{ minWidth: 120, whiteSpace: 'nowrap' }}
           >
-            Set PIN
+            {isSaved ? '✓ Saved' : 'Save PIN'}
           </Button>
         </Stack>
+
+        {pinMessage && (
+          <Alert
+            severity={pinMessage.tone === 'info' ? 'info' : pinMessage.tone}
+            sx={{ mt: 2 }}
+            onClose={() => setPinMessage(null)}
+          >
+            {pinMessage.text}
+          </Alert>
+        )}
+
+        {isSaved && (
+          <Box sx={{ mt: 2 }}>
+            {!showChangePin ? (
+              <Button
+                variant="text"
+                size="small"
+                onClick={() => setShowChangePin(true)}
+                sx={{
+                  px: 0,
+                  color: tokens.inkDim,
+                  fontFamily: '"IBM Plex Mono", monospace',
+                  fontSize: '0.72rem',
+                  letterSpacing: '0.1em',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Change PIN on-chain →
+              </Button>
+            ) : (
+              <Stack
+                direction={{ xs: 'column', md: 'row' }}
+                spacing={1.5}
+                alignItems={{ xs: 'stretch', md: 'center' }}
+                sx={{
+                  pt: 3,
+                  borderTop: `1px solid ${tokens.hairline}`,
+                }}
+              >
+                <TextField
+                  fullWidth
+                  size="small"
+                  label="New PIN"
+                  placeholder="4–6 digits"
+                  type="text"
+                  inputMode="numeric"
+                  value={newPin}
+                  onChange={handleNewPinChange}
+                  InputLabelProps={{ shrink: true }}
+                  inputProps={{ maxLength: 6, autoComplete: 'off' }}
+                  disabled={isChangingPin}
+                />
+                <Button
+                  variant="contained"
+                  onClick={handleChangePin}
+                  disabled={isChangingPin || newPin.length < 4 || newPin === savedPin}
+                  sx={{ minWidth: 160, whiteSpace: 'nowrap' }}
+                >
+                  {isChangingPin ? (
+                    <>
+                      <CircularProgress size={14} thickness={4} sx={{ color: 'inherit', mr: 1 }} />
+                      Migrating…
+                    </>
+                  ) : (
+                    'Change PIN →'
+                  )}
+                </Button>
+                <Button
+                  variant="text"
+                  size="small"
+                  onClick={() => {
+                    setShowChangePin(false);
+                    setNewPin('');
+                  }}
+                  disabled={isChangingPin}
+                  sx={{ color: tokens.inkMuted }}
+                >
+                  Cancel
+                </Button>
+              </Stack>
+            )}
+          </Box>
+        )}
 
         {/* Stats grid — editorial */}
         <Box

--- a/zkloan-credit-scorer-ui/src/components/PrivateStateCard.tsx
+++ b/zkloan-credit-scorer-ui/src/components/PrivateStateCard.tsx
@@ -12,7 +12,6 @@ import {
   Button,
   Stack,
   Alert,
-  CircularProgress,
 } from '@mui/material';
 import { useZKLoanContext } from '../hooks';
 import { userProfiles } from '../utils/loanProfiles';
@@ -113,13 +112,9 @@ export const PrivateStateCard: React.FC = () => {
     secretPin,
     setSecretPin,
     refreshLoans,
-    changePin,
   } = useZKLoanContext();
   const [selectedProfile, setSelectedProfile] = React.useState(0);
   const [savedPin, setSavedPin] = useState<string | null>(null);
-  const [showChangePin, setShowChangePin] = useState(false);
-  const [newPin, setNewPin] = useState('');
-  const [isChangingPin, setIsChangingPin] = useState(false);
   const [pinMessage, setPinMessage] = useState<{ tone: 'success' | 'error' | 'info'; text: string } | null>(null);
 
   const currentProfile = userProfiles[selectedProfile];
@@ -146,61 +141,30 @@ export const PrivateStateCard: React.FC = () => {
     setCurrentProfileId(profile.applicantId);
   };
 
+  // Contract uses Uint<16> for the PIN (max 65535). We keep the UI cap at
+  // 4 digits to avoid users entering a valid-looking 5/6-digit number that
+  // overflows the circuit type at submission time.
+  const MAX_PIN_DIGITS = 4;
+
   const handlePinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/\D/g, '').slice(0, 6);
+    const value = e.target.value.replace(/\D/g, '').slice(0, MAX_PIN_DIGITS);
     setSecretPin(value);
-    // Clear stale confirmation if the user is editing
     if (savedPin !== null && value !== savedPin) {
       setPinMessage(null);
     }
-  };
-
-  const handleNewPinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNewPin(e.target.value.replace(/\D/g, '').slice(0, 6));
   };
 
   const handleSavePin = () => {
     setSavedPin(secretPin);
     setPinMessage({
       tone: 'success',
-      text: 'PIN saved locally. It will be used to derive your identity when you request or respond to a loan.',
+      text:
+        'PIN saved locally. It never leaves this device — it is hashed into the public key used on-chain.',
     });
     refreshLoans();
   };
 
-  const handleChangePin = async () => {
-    if (!savedPin) return;
-    if (newPin === savedPin) {
-      setPinMessage({ tone: 'error', text: 'New PIN must differ from the current PIN.' });
-      return;
-    }
-    if (newPin.length < 4 || newPin.length > 6) {
-      setPinMessage({ tone: 'error', text: 'New PIN must be 4–6 digits.' });
-      return;
-    }
-    setIsChangingPin(true);
-    setPinMessage({ tone: 'info', text: 'Submitting on-chain PIN migration…' });
-    try {
-      await changePin(BigInt(savedPin), BigInt(newPin));
-      setSavedPin(newPin);
-      setNewPin('');
-      setShowChangePin(false);
-      setPinMessage({
-        tone: 'success',
-        text:
-          'PIN change submitted. On-chain migration moves up to 5 loans per call — if you had more, click Change PIN again to continue.',
-      });
-    } catch (err) {
-      setPinMessage({
-        tone: 'error',
-        text: `PIN change failed: ${err instanceof Error ? err.message : String(err)}`,
-      });
-    } finally {
-      setIsChangingPin(false);
-    }
-  };
-
-  const isPinValid = secretPin.length >= 4 && secretPin.length <= 6;
+  const isPinValid = secretPin.length >= 4 && secretPin.length <= MAX_PIN_DIGITS;
   const isSaved = savedPin !== null && savedPin === secretPin;
 
   return (
@@ -259,13 +223,13 @@ export const PrivateStateCard: React.FC = () => {
             fullWidth
             size="small"
             label="Secret PIN"
-            placeholder="4–6 digits"
+            placeholder="4 digits"
             type="text"
             inputMode="numeric"
             value={secretPin}
             onChange={handlePinChange}
             InputLabelProps={{ shrink: true }}
-            inputProps={{ maxLength: 6, autoComplete: 'off' }}
+            inputProps={{ maxLength: MAX_PIN_DIGITS, autoComplete: 'off' }}
           />
 
           <Button
@@ -286,79 +250,6 @@ export const PrivateStateCard: React.FC = () => {
           >
             {pinMessage.text}
           </Alert>
-        )}
-
-        {isSaved && (
-          <Box sx={{ mt: 2 }}>
-            {!showChangePin ? (
-              <Button
-                variant="text"
-                size="small"
-                onClick={() => setShowChangePin(true)}
-                sx={{
-                  px: 0,
-                  color: tokens.inkDim,
-                  fontFamily: '"IBM Plex Mono", monospace',
-                  fontSize: '0.72rem',
-                  letterSpacing: '0.1em',
-                  textTransform: 'uppercase',
-                }}
-              >
-                Change PIN on-chain →
-              </Button>
-            ) : (
-              <Stack
-                direction={{ xs: 'column', md: 'row' }}
-                spacing={1.5}
-                alignItems={{ xs: 'stretch', md: 'center' }}
-                sx={{
-                  pt: 3,
-                  borderTop: `1px solid ${tokens.hairline}`,
-                }}
-              >
-                <TextField
-                  fullWidth
-                  size="small"
-                  label="New PIN"
-                  placeholder="4–6 digits"
-                  type="text"
-                  inputMode="numeric"
-                  value={newPin}
-                  onChange={handleNewPinChange}
-                  InputLabelProps={{ shrink: true }}
-                  inputProps={{ maxLength: 6, autoComplete: 'off' }}
-                  disabled={isChangingPin}
-                />
-                <Button
-                  variant="contained"
-                  onClick={handleChangePin}
-                  disabled={isChangingPin || newPin.length < 4 || newPin === savedPin}
-                  sx={{ minWidth: 160, whiteSpace: 'nowrap' }}
-                >
-                  {isChangingPin ? (
-                    <>
-                      <CircularProgress size={14} thickness={4} sx={{ color: 'inherit', mr: 1 }} />
-                      Migrating…
-                    </>
-                  ) : (
-                    'Change PIN →'
-                  )}
-                </Button>
-                <Button
-                  variant="text"
-                  size="small"
-                  onClick={() => {
-                    setShowChangePin(false);
-                    setNewPin('');
-                  }}
-                  disabled={isChangingPin}
-                  sx={{ color: tokens.inkMuted }}
-                >
-                  Cancel
-                </Button>
-              </Stack>
-            )}
-          </Box>
         )}
 
         {/* Stats grid — editorial */}

--- a/zkloan-credit-scorer-ui/src/contexts/ZKLoanContext.tsx
+++ b/zkloan-credit-scorer-ui/src/contexts/ZKLoanContext.tsx
@@ -30,7 +30,8 @@ import {
 import { FetchZkConfigProvider } from '@midnight-ntwrk/midnight-js-fetch-zk-config-provider';
 import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
 import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
-import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { getNetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { MidnightBech32m, ShieldedAddress } from '@midnight-ntwrk/wallet-sdk-address-format';
 import { deployContract, findDeployedContract, submitCallTx } from '@midnight-ntwrk/midnight-js-contracts';
 import { type PrivateStateProvider } from '@midnight-ntwrk/midnight-js-types';
 import { CompiledContract } from '@midnight-ntwrk/compact-js';
@@ -265,15 +266,24 @@ export const ZKLoanProvider: React.FC<Readonly<ZKLoanProviderProps>> = ({ logger
     setIsConnected(true);
     setWalletAddress(addresses.shieldedAddress || null);
 
-    // Store the coin public key bytes for later use in getMyLoans
-    if (addresses.shieldedCoinPublicKey) {
-      const coinPkBytes = typeof addresses.shieldedCoinPublicKey === 'string'
-        ? new Uint8Array(Buffer.from(addresses.shieldedCoinPublicKey, 'hex'))
-        : new Uint8Array(addresses.shieldedCoinPublicKey as ArrayBuffer);
-      setWalletPublicKeyBytes(coinPkBytes);
-      logger.info({ coinPkBytesLength: coinPkBytes.length }, 'Stored coin public key bytes');
+    // Decode the coin public key from the bech32 shielded address. The
+    // dapp-connector-api `shieldedCoinPublicKey` field changed shape across
+    // SDK versions; the bech32 address is the canonical source.
+    if (addresses.shieldedAddress) {
+      try {
+        const decoded = MidnightBech32m.parse(addresses.shieldedAddress)
+          .decode(ShieldedAddress, getNetworkId());
+        const coinPkBytes = new Uint8Array(decoded.coinPublicKey.data);
+        if (coinPkBytes.length !== 32) {
+          throw new Error(`Expected 32-byte coin public key, got ${coinPkBytes.length}`);
+        }
+        setWalletPublicKeyBytes(coinPkBytes);
+        logger.info({ coinPkBytesLength: coinPkBytes.length }, 'Stored coin public key bytes');
+      } catch (err) {
+        logger.error({ err }, 'Failed to decode shielded address for coin public key');
+      }
     } else {
-      logger.warn('No shieldedCoinPublicKey received from wallet');
+      logger.warn('No shieldedAddress received from wallet');
     }
 
     logger.info({

--- a/zkloan-credit-scorer-ui/src/contexts/ZKLoanContext.tsx
+++ b/zkloan-credit-scorer-ui/src/contexts/ZKLoanContext.tsx
@@ -88,6 +88,7 @@ export interface ZKLoanAPIProvider {
   readonly join: (contractAddress: ContractAddress) => void;
   readonly requestLoan: (amount: bigint) => Promise<void>;
   readonly respondToLoan: (loanId: bigint, accept: boolean) => Promise<void>;
+  readonly changePin: (oldPin: bigint, newPin: bigint) => Promise<void>;
   readonly refreshLoans: () => Promise<void>;
   readonly getMyLoans: () => Promise<UserLoan[]>;
   readonly lastLoanUpdate: number;
@@ -628,6 +629,33 @@ export const ZKLoanProvider: React.FC<Readonly<ZKLoanProviderProps>> = ({ logger
     setLastLoanUpdate(Date.now());
   }, [providersRef, compiledContractRef, contractAddressRef, logger, secretPin]);
 
+  const changePinTx = useCallback(async (oldPin: bigint, newPin: bigint) => {
+    if (!providersRef || !compiledContractRef || !contractAddressRef) {
+      throw new Error('Contract not deployed. Please deploy or join a contract first.');
+    }
+    if (oldPin === newPin) {
+      throw new Error('Old and new PIN must differ.');
+    }
+
+    setFlowMessage('Changing PIN on-chain (this migrates up to 5 loans per batch)...');
+    logger.info(`Changing PIN: ${oldPin} -> ${newPin}`);
+
+    const finalizedTxData = await submitCallTx(providersRef, {
+      compiledContract: compiledContractRef,
+      contractAddress: contractAddressRef,
+      circuitId: 'changePin' as ZKLoanCircuitKeys,
+      args: [oldPin, newPin] as [bigint, bigint],
+      privateStateId: 'zkLoanCreditScorerPrivateState',
+    });
+
+    setFlowMessage(undefined);
+    logger.info(`Transaction ${finalizedTxData.public.txId} added in block ${finalizedTxData.public.blockHeight}`);
+
+    // Local state follows the new PIN so subsequent actions use the right key
+    setSecretPin(newPin.toString());
+    setLastLoanUpdate(Date.now());
+  }, [providersRef, compiledContractRef, contractAddressRef, logger]);
+
   const getMyLoans = useCallback(async (): Promise<UserLoan[]> => {
     if (!publicDataProviderRef || !contractAddressRef || !walletPublicKeyBytes) {
       logger.warn('Cannot get loans: missing provider, contract address, or wallet public key');
@@ -746,6 +774,7 @@ export const ZKLoanProvider: React.FC<Readonly<ZKLoanProviderProps>> = ({ logger
     join: joinExistingContract,
     requestLoan: requestLoanTx,
     respondToLoan: respondToLoanTx,
+    changePin: changePinTx,
     refreshLoans,
     getMyLoans,
     lastLoanUpdate,

--- a/zkloan-credit-scorer-ui/src/contexts/ZKLoanContext.tsx
+++ b/zkloan-credit-scorer-ui/src/contexts/ZKLoanContext.tsx
@@ -88,7 +88,6 @@ export interface ZKLoanAPIProvider {
   readonly join: (contractAddress: ContractAddress) => void;
   readonly requestLoan: (amount: bigint) => Promise<void>;
   readonly respondToLoan: (loanId: bigint, accept: boolean) => Promise<void>;
-  readonly changePin: (oldPin: bigint, newPin: bigint) => Promise<void>;
   readonly refreshLoans: () => Promise<void>;
   readonly getMyLoans: () => Promise<UserLoan[]>;
   readonly lastLoanUpdate: number;
@@ -629,33 +628,6 @@ export const ZKLoanProvider: React.FC<Readonly<ZKLoanProviderProps>> = ({ logger
     setLastLoanUpdate(Date.now());
   }, [providersRef, compiledContractRef, contractAddressRef, logger, secretPin]);
 
-  const changePinTx = useCallback(async (oldPin: bigint, newPin: bigint) => {
-    if (!providersRef || !compiledContractRef || !contractAddressRef) {
-      throw new Error('Contract not deployed. Please deploy or join a contract first.');
-    }
-    if (oldPin === newPin) {
-      throw new Error('Old and new PIN must differ.');
-    }
-
-    setFlowMessage('Changing PIN on-chain (this migrates up to 5 loans per batch)...');
-    logger.info(`Changing PIN: ${oldPin} -> ${newPin}`);
-
-    const finalizedTxData = await submitCallTx(providersRef, {
-      compiledContract: compiledContractRef,
-      contractAddress: contractAddressRef,
-      circuitId: 'changePin' as ZKLoanCircuitKeys,
-      args: [oldPin, newPin] as [bigint, bigint],
-      privateStateId: 'zkLoanCreditScorerPrivateState',
-    });
-
-    setFlowMessage(undefined);
-    logger.info(`Transaction ${finalizedTxData.public.txId} added in block ${finalizedTxData.public.blockHeight}`);
-
-    // Local state follows the new PIN so subsequent actions use the right key
-    setSecretPin(newPin.toString());
-    setLastLoanUpdate(Date.now());
-  }, [providersRef, compiledContractRef, contractAddressRef, logger]);
-
   const getMyLoans = useCallback(async (): Promise<UserLoan[]> => {
     if (!publicDataProviderRef || !contractAddressRef || !walletPublicKeyBytes) {
       logger.warn('Cannot get loans: missing provider, contract address, or wallet public key');
@@ -774,7 +746,6 @@ export const ZKLoanProvider: React.FC<Readonly<ZKLoanProviderProps>> = ({ logger
     join: joinExistingContract,
     requestLoan: requestLoanTx,
     respondToLoan: respondToLoanTx,
-    changePin: changePinTx,
     refreshLoans,
     getMyLoans,
     lastLoanUpdate,


### PR DESCRIPTION
Closes #18
Closes #19
Closes #20
Closes #21

## #18 CLI admin actions accept bech32 addresses

`blacklistUser`, `removeBlacklistUser`, and `transferAdmin` now accept either a shielded address (`mn_shield-addr_…`) or a 32-byte hex key. Bech32 is parsed with `MidnightBech32m.parse` + `ShieldedAddress.codec`; the coin public key is extracted and the encryption key is discarded. Hex is kept as a fallback with validation.

New helper: [zkloan-credit-scorer-cli/src/address-utils.ts](zkloan-credit-scorer-cli/src/address-utils.ts). Prompts now read, e.g.:

> `Enter the user to blacklist (shielded address \`mn_shield-addr_…\` or 32-byte hex public key):`

Added `@midnight-ntwrk/wallet-sdk-address-format@3.1.0` as a direct root dependency (it was previously transitive).

## #19 NIGHT labels, separate DUST line

The CLI was logging native-token balances as "tDUST". NIGHT is the user currency; DUST is the fee resource. `displayWalletBalances` now prints:

```
Unshielded NIGHT balance: …
Shielded NIGHT balance:   …
Total NIGHT balance:      …
DUST balance (for fees):  …
```

Return shape extended with `dust: bigint` — non-breaking since the existing callers only read `total`. Waiting-for-funds log line also clarified.

## #20 Loan amount includes USD units

CLI prompt:

> `Enter the loan amount (USD, 1-65535 — the contract caps approvals at $10,000 / $7,000 / $3,000 per tier):`

Submission log now reads `Requesting loan for $N (USD) with PIN...`. The UI's loan form already renders a \`$\` adornment so no UI change was required.

## #21 "Set PIN" gives feedback; on-chain Change PIN wired up

- Renamed the button from **Set PIN** to **Save PIN**. On click it flips to a disabled **✓ Saved** state and shows an inline sage confirmation explaining that the PIN is a local secret used to derive the user's identity.
- A subtle **Change PIN on-chain →** link appears after saving. Expanding it slides in a New PIN field plus a primary **Change PIN →** button that submits the \`changePin\` circuit.
- Added \`changePin(oldPin, newPin)\` to \`ZKLoanContext\` via \`submitCallTx\`. The success message notes that large loan histories require multiple clicks (the circuit migrates up to 5 loans per call by design).
- Errors surface inline with the real cause.

## Verification

- \`npm run typecheck\` — all four workspaces clean
- \`cd contract && npm test\` — **61/61** passing
- \`cd zkloan-credit-scorer-cli && npm run build\` — ok
- \`cd zkloan-credit-scorer-ui && npm run build\` — ok

## Test plan

- [ ] CLI: request a loan from standalone — prompt shows USD clarifier and tier caps, log shows `$` prefix
- [ ] CLI: `Display wallet balances` prints four lines (3× NIGHT + 1× DUST)
- [ ] CLI admin menu: paste a Preprod shielded address into each admin prompt and confirm the tx lands
- [ ] CLI admin menu: paste a raw 64-char hex key and confirm the tx still lands (backwards compat)
- [ ] UI: Save PIN → confirmation appears, button flips to ✓ Saved
- [ ] UI: open Change PIN → field → submit → migration tx lands, local PIN updates to new value