### PR TITLE
chore: fix pre-existing lint/CI failures (contract + CLI)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,9 +33,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Node.js
+        # Pinned to 22 (the project's minimum supported engine): restify, used
+        # by the attestation API, pulls spdy -> http-deceiver, which calls the
+        # process.binding('http_parser') internal removed in Node 23+. Node 24
+        # therefore breaks `require('restify')` at import. Revisit if/when the
+        # attestation API migrates off restify.
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '24'
+          node-version: '22'
 
       # npm < 11 mishandles platform-specific optional dependencies, breaking the
       # build. setup-node still ships an older npm. See https://github.com/npm/cli/issues/4828

--- a/contract/.prettierignore
+++ b/contract/.prettierignore
@@ -1,0 +1,2 @@
+src/managed/
+dist/

--- a/contract/.prettierrc
+++ b/contract/.prettierrc
@@ -1,1 +1,6 @@
-{ "trailingComma": "none" }
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 120
+}

--- a/contract/eslint.config.mjs
+++ b/contract/eslint.config.mjs
@@ -28,6 +28,12 @@ export default [
         ecmaVersion: "latest",
         sourceType: "module",
         project: ["./tsconfig.json"]
+      },
+      globals: {
+        process: "readonly",
+        Buffer: "readonly",
+        URL: "readonly",
+        setTimeout: "readonly"
       }
     },
     plugins: {

--- a/contract/src/index.ts
+++ b/contract/src/index.ts
@@ -13,5 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * as ZKLoanCreditScorer from "./managed/zkloan-credit-scorer/contract/index.js";
-export * from "./witnesses.js";
+export * as ZKLoanCreditScorer from './managed/zkloan-credit-scorer/contract/index.js';
+export * from './witnesses.js';

--- a/contract/src/test/utils/address.ts
+++ b/contract/src/test/utils/address.ts
@@ -1,6 +1,5 @@
 import { encodeCoinPublicKey } from '@midnight-ntwrk/compact-runtime';
 import { encodeContractAddress } from '@midnight-ntwrk/ledger-v8';
-import type * as Compact from '../../managed/zkloan-credit-scorer/contract/index.js';
 
 /**
  * @description Converts an ASCII string to its hexadecimal representation,
@@ -10,14 +9,14 @@ import type * as Compact from '../../managed/zkloan-credit-scorer/contract/index
  * @param len Total desired length of the resulting hex string. Defaults to 64.
  * @returns Hexadecimal string representation of `str`, padded to `length` characters.
  */
-export const toHexPadded = (str: string, len = 64) =>
-  Buffer.from(str, 'ascii').toString('hex').padStart(len, '0');
+export const toHexPadded = (str: string, len = 64) => Buffer.from(str, 'ascii').toString('hex').padStart(len, '0');
 /**
  * @description Generates ZswapCoinPublicKey from `str` for testing purposes.
  * @param str String to hexify and encode.
  * @returns Encoded `ZswapCoinPublicKey`.
  */
-export const encodeToPK = (str: string): any  => ({ // TODO: look for ZswapCoinPublicKey type
+export const encodeToPK = (str: string): any => ({
+  // TODO: look for ZswapCoinPublicKey type
   bytes: encodeCoinPublicKey(toHexPadded(str)),
   hex: toHexPadded(str),
 });
@@ -27,9 +26,9 @@ export const encodeToPK = (str: string): any  => ({ // TODO: look for ZswapCoinP
  * @param str String to hexify and encode.
  * @returns Encoded ContractAddress.
  */
-export const encodeToAddress = (str: string): any  => ({
+export const encodeToAddress = (str: string): any => ({
   bytes: encodeContractAddress(toHexPadded(str)),
-}); 
+});
 
 /**
  * @description Generates an Either object for ZswapCoinPublicKey for testing.
@@ -42,4 +41,3 @@ export const createEitherTestUser = (str: string) => ({
   left: encodeToPK(str),
   right: encodeToAddress(''),
 });
-

--- a/contract/src/test/utils/test-data.ts
+++ b/contract/src/test/utils/test-data.ts
@@ -4,70 +4,70 @@
 
 import { type ZKLoanCreditScorerPrivateState } from '../../witnesses.js';
 import { pureCircuits, type Schnorr_SchnorrSignature } from '../../managed/zkloan-credit-scorer/contract/index.js';
-import { ecMulGenerator, addField, mulField, type JubjubPoint } from '@midnight-ntwrk/compact-runtime';
+import { ecMulGenerator, type JubjubPoint } from '@midnight-ntwrk/compact-runtime';
 import * as crypto from 'crypto';
 
 export const userProfiles = [
   {
-    "applicantId": "user-001",
-    "creditScore": 720,
-    "monthlyIncome": 2500,
-    "monthsAsCustomer": 24
+    applicantId: 'user-001',
+    creditScore: 720,
+    monthlyIncome: 2500,
+    monthsAsCustomer: 24,
   },
   {
-    "applicantId": "user-002",
-    "creditScore": 650,
-    "monthlyIncome": 1800,
-    "monthsAsCustomer": 11
+    applicantId: 'user-002',
+    creditScore: 650,
+    monthlyIncome: 1800,
+    monthsAsCustomer: 11,
   },
   {
-    "applicantId": "user-003",
-    "creditScore": 580,
-    "monthlyIncome": 2200,
-    "monthsAsCustomer": 36
+    applicantId: 'user-003',
+    creditScore: 580,
+    monthlyIncome: 2200,
+    monthsAsCustomer: 36,
   },
   {
-    "applicantId": "user-004",
-    "creditScore": 710,
-    "monthlyIncome": 1900,
-    "monthsAsCustomer": 5
+    applicantId: 'user-004',
+    creditScore: 710,
+    monthlyIncome: 1900,
+    monthsAsCustomer: 5,
   },
   {
-    "applicantId": "user-005",
-    "creditScore": 520,
-    "monthlyIncome": 3000,
-    "monthsAsCustomer": 48
+    applicantId: 'user-005',
+    creditScore: 520,
+    monthlyIncome: 3000,
+    monthsAsCustomer: 48,
   },
   {
-    "applicantId": "user-006",
-    "creditScore": 810,
-    "monthlyIncome": 4500,
-    "monthsAsCustomer": 60
+    applicantId: 'user-006',
+    creditScore: 810,
+    monthlyIncome: 4500,
+    monthsAsCustomer: 60,
   },
   {
-    "applicantId": "user-007",
-    "creditScore": 639,
-    "monthlyIncome": 2100,
-    "monthsAsCustomer": 18
+    applicantId: 'user-007',
+    creditScore: 639,
+    monthlyIncome: 2100,
+    monthsAsCustomer: 18,
   },
   {
-    "applicantId": "user-008",
-    "creditScore": 680,
-    "monthlyIncome": 1450,
-    "monthsAsCustomer": 30
+    applicantId: 'user-008',
+    creditScore: 680,
+    monthlyIncome: 1450,
+    monthsAsCustomer: 30,
   },
   {
-    "applicantId": "user-009",
-    "creditScore": 750,
-    "monthlyIncome": 2100,
-    "monthsAsCustomer": 23
+    applicantId: 'user-009',
+    creditScore: 750,
+    monthlyIncome: 2100,
+    monthsAsCustomer: 23,
   },
   {
-    "applicantId": "user-010",
-    "creditScore": 579,
-    "monthlyIncome": 1900,
-    "monthsAsCustomer": 12
-  }
+    applicantId: 'user-010',
+    creditScore: 579,
+    monthlyIncome: 1900,
+    monthsAsCustomer: 12,
+  },
 ];
 
 // Jubjub curve order for scalar field
@@ -87,10 +87,7 @@ export function generateProviderKeyPair(): { sk: bigint; pk: JubjubPoint } {
 
 const TWO_248 = 452312848583266388373324160190187140051835877600158453279131187530910662656n;
 
-export function schnorrSign(
-  sk: bigint,
-  msg: bigint[],
-): Schnorr_SchnorrSignature {
+export function schnorrSign(sk: bigint, msg: bigint[]): Schnorr_SchnorrSignature {
   const pk = ecMulGenerator(sk);
   const k = randomScalar();
   const R = ecMulGenerator(k);
@@ -101,7 +98,7 @@ export function schnorrSign(
   // Compute response: s = (k + c * sk) mod JUBJUB_ORDER
   // We must reduce mod JUBJUB_ORDER (not BLS12-381 Fr) because ecMulGenerator
   // requires scalars < JUBJUB_ORDER.
-  const s = ((k + c * sk) % JUBJUB_ORDER + JUBJUB_ORDER) % JUBJUB_ORDER;
+  const s = (((k + c * sk) % JUBJUB_ORDER) + JUBJUB_ORDER) % JUBJUB_ORDER;
   return { announcement: R, response: s };
 }
 

--- a/contract/src/test/zkloan-credit-scorer.simulator.ts
+++ b/contract/src/test/zkloan-credit-scorer.simulator.ts
@@ -21,16 +21,11 @@ import {
   type JubjubPoint,
   transientHash,
   CompactTypeBytes,
-} from "@midnight-ntwrk/compact-runtime";
-import {
-  Contract,
-  type Ledger,
-  ledger,
-  pureCircuits
-} from "../managed/zkloan-credit-scorer/contract/index.js";
-import { type ZKLoanCreditScorerPrivateState, witnesses } from "../witnesses.js";
-import { createEitherTestUser } from "./utils/address.js";
-import { createSignedUserProfile, generateUserSecret, generateProviderKeyPair } from "./utils/test-data.js";
+} from '@midnight-ntwrk/compact-runtime';
+import { Contract, type Ledger, ledger, pureCircuits } from '../managed/zkloan-credit-scorer/contract/index.js';
+import { type ZKLoanCreditScorerPrivateState, witnesses } from '../witnesses.js';
+import { createEitherTestUser } from './utils/address.js';
+import { createSignedUserProfile, generateUserSecret, generateProviderKeyPair } from './utils/test-data.js';
 
 const bytes32Type = new CompactTypeBytes(32);
 
@@ -43,7 +38,7 @@ export class ZKLoanCreditScorerSimulator {
   readonly userSecretKey: Uint8Array;
 
   constructor() {
-    const user = createEitherTestUser("Alice");
+    const user = createEitherTestUser('Alice');
     this.contract = new Contract<ZKLoanCreditScorerPrivateState>(witnesses);
 
     // Generate provider key pair
@@ -68,18 +63,14 @@ export class ZKLoanCreditScorerSimulator {
       this.userSecretKey,
     );
 
-    const {
-      currentPrivateState,
-      currentContractState,
-      currentZswapLocalState
-    } = this.contract.initialState(
-      createConstructorContext(initialPrivateState, user.left.hex)
+    const { currentPrivateState, currentContractState, currentZswapLocalState } = this.contract.initialState(
+      createConstructorContext(initialPrivateState, user.left.hex),
     );
     this.circuitContext = createCircuitContext(
       sampleContractAddress(),
       currentZswapLocalState,
       currentContractState,
-      currentPrivateState
+      currentPrivateState,
     );
 
     // Register the default provider
@@ -132,33 +123,27 @@ export class ZKLoanCreditScorerSimulator {
     this.circuitContext = this.contract.impureCircuits.requestLoan(
       this.circuitContext,
       amountRequested,
-      secretPin
+      secretPin,
     ).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
   public blacklistUser(userPubKey: Uint8Array): Ledger {
-    this.circuitContext = this.contract.impureCircuits.blacklistUser(
-      this.circuitContext,
-      { bytes: userPubKey }
-    ).context;
+    this.circuitContext = this.contract.impureCircuits.blacklistUser(this.circuitContext, {
+      bytes: userPubKey,
+    }).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
   public removeBlacklistUser(userPubKey: Uint8Array): Ledger {
-    this.circuitContext = this.contract.impureCircuits.removeBlacklistUser(
-      this.circuitContext,
-      { bytes: userPubKey }
-    ).context;
+    this.circuitContext = this.contract.impureCircuits.removeBlacklistUser(this.circuitContext, {
+      bytes: userPubKey,
+    }).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
   public changePin(oldPin: bigint, newPin: bigint): Ledger {
-    this.circuitContext = this.contract.impureCircuits.changePin(
-      this.circuitContext,
-      oldPin,
-      newPin
-    ).context;
+    this.circuitContext = this.contract.impureCircuits.changePin(this.circuitContext, oldPin, newPin).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
@@ -167,16 +152,15 @@ export class ZKLoanCreditScorerSimulator {
       this.circuitContext,
       loanId,
       secretPin,
-      accept
+      accept,
     ).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
   public rotateAdmin(newAdminPublicKey: Uint8Array): Ledger {
-    this.circuitContext = this.contract.impureCircuits.rotateAdmin(
-      this.circuitContext,
-      { bytes: newAdminPublicKey }
-    ).context;
+    this.circuitContext = this.contract.impureCircuits.rotateAdmin(this.circuitContext, {
+      bytes: newAdminPublicKey,
+    }).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
@@ -184,16 +168,13 @@ export class ZKLoanCreditScorerSimulator {
     this.circuitContext = this.contract.impureCircuits.registerProvider(
       this.circuitContext,
       providerId,
-      providerPk
+      providerPk,
     ).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
   public removeProvider(providerId: bigint): Ledger {
-    this.circuitContext = this.contract.impureCircuits.removeProvider(
-      this.circuitContext,
-      providerId
-    ).context;
+    this.circuitContext = this.contract.impureCircuits.removeProvider(this.circuitContext, providerId).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 

--- a/contract/src/test/zkloan-credit-scorer.test.ts
+++ b/contract/src/test/zkloan-credit-scorer.test.ts
@@ -13,18 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ZKLoanCreditScorerSimulator } from "./zkloan-credit-scorer.simulator.js";
-import { createSignedUserProfile, createCustomSignedProfile, generateProviderKeyPair, schnorrSign } from "./utils/test-data.js";
-import { setNetworkId } from "@midnight-ntwrk/midnight-js-network-id";
-import { describe, it, expect } from "vitest";
+import { ZKLoanCreditScorerSimulator } from './zkloan-credit-scorer.simulator.js';
+import { createCustomSignedProfile, generateProviderKeyPair } from './utils/test-data.js';
+import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { describe, it, expect } from 'vitest';
 
-setNetworkId("undeployed");
+setNetworkId('undeployed');
 
-    const bigintReplacer = (_key: string, value: any) =>
-      typeof value === 'bigint' ? value.toString() : value;
-
-describe("ZKLoanCreditScorer smart contract", () => {
-
+describe('ZKLoanCreditScorer smart contract', () => {
   // Helper: set up private state with valid attestation for a given profile.
   // Binds the attestation message to the simulator's witness-derived user
   // pubkey at the given PIN. The simulator's `userSecretKey` is preserved so
@@ -48,7 +44,7 @@ describe("ZKLoanCreditScorer smart contract", () => {
     );
   }
 
-   it("generates initial ledger state deterministically", () => {
+  it('generates initial ledger state deterministically', () => {
     const simulator0 = new ZKLoanCreditScorerSimulator();
     const simulator1 = new ZKLoanCreditScorerSimulator();
 
@@ -60,9 +56,8 @@ describe("ZKLoanCreditScorer smart contract", () => {
     expect(ledger1.providers.member(1n)).toBeTruthy();
   });
 
-  it("approves a Tier 1 loan and caps at the max amount", () => {
+  it('approves a Tier 1 loan and caps at the max amount', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     const userPubKey = simulator.deriveUserPublicKey(simulator.userSecretKey, userPin);
@@ -76,9 +71,8 @@ describe("ZKLoanCreditScorer smart contract", () => {
     expect(loan.authorizedAmount).toEqual(1500n);
   });
 
-  it("approves a Tier 2 loan and gives the requested amount", () => {
+  it('approves a Tier 2 loan and gives the requested amount', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 650n, 1600n, 10n, userPin);
@@ -96,9 +90,8 @@ describe("ZKLoanCreditScorer smart contract", () => {
     expect(loan.authorizedAmount).toEqual(5000n); // Gets the requested amount
   });
 
-  it("proposes a Tier 3 loan when amount exceeds limit", () => {
+  it('proposes a Tier 3 loan when amount exceeds limit', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 590n, 1000n, 1n, userPin);
@@ -111,9 +104,8 @@ describe("ZKLoanCreditScorer smart contract", () => {
     expect(loan.authorizedAmount).toEqual(3000n); // Capped at Tier 3 max
   });
 
-  it("rejects a loan for a non-eligible applicant", () => {
+  it('rejects a loan for a non-eligible applicant', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 500n, 1000n, 1n, userPin);
@@ -126,9 +118,8 @@ describe("ZKLoanCreditScorer smart contract", () => {
     expect(loan.authorizedAmount).toEqual(0n);
   });
 
-  it("creates multiple loans for the same user with incrementing IDs", () => {
+  it('creates multiple loans for the same user with incrementing IDs', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 800n, 3000n, 30n, userPin);
@@ -146,7 +137,7 @@ describe("ZKLoanCreditScorer smart contract", () => {
     expect(userLoans.lookup(3n).authorizedAmount).toEqual(300n);
   });
 
-  it("throws an error if the user is blacklisted", () => {
+  it('throws an error if the user is blacklisted', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const userPin = 1234n;
 
@@ -158,12 +149,12 @@ describe("ZKLoanCreditScorer smart contract", () => {
 
     expect(() => {
       simulator.requestLoan(1000n, userPin);
-    }).toThrow("Requester is blacklisted");
+    }).toThrow('Requester is blacklisted');
   });
 
-  it("allows admin to blacklist and remove a user", () => {
+  it('allows admin to blacklist and remove a user', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const bobZwapKey = simulator.createTestUser("Bob").left.bytes;
+    const bobZwapKey = simulator.createTestUser('Bob').left.bytes;
     let ledger = simulator.getLedger();
 
     // Check Bob is not blacklisted
@@ -180,9 +171,8 @@ describe("ZKLoanCreditScorer smart contract", () => {
     expect(ledger.blacklist.member({ bytes: bobZwapKey })).toBeFalsy();
   });
 
-it("migrates a small number of loans (1 batch) and cleans up", () => {
+  it('migrates a small number of loans (1 batch) and cleans up', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const oldPin = 1234n;
     const newPin = 9876n;
 
@@ -214,9 +204,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(ledger.loans.lookup(newPubKey).lookup(2n).authorizedAmount).toEqual(200n);
   });
 
-  it("migrates multiple batches of loans (7 loans) correctly", () => {
+  it('migrates multiple batches of loans (7 loans) correctly', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const oldPin = 1234n;
     const newPin = 9876n;
 
@@ -246,7 +235,7 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     expect(ledger.loans.lookup(oldPubKey).member(6n)).toBeTruthy(); // Check loan 6 still with old key
 
-// --- BATCH 2 (Migrates 6-7, finds 8-10 empty, finishes) ---
+    // --- BATCH 2 (Migrates 6-7, finds 8-10 empty, finishes) ---
     simulator.changePin(oldPin, newPin);
 
     ledger = simulator.getLedger();
@@ -262,9 +251,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(ledger.loans.member(oldPubKey)).toBeFalsy();
   });
 
-  it("throws an error if user tries to requestLoan during migration", () => {
+  it('throws an error if user tries to requestLoan during migration', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
 
     const oldPin = 1234n;
     const newPin = 9876n;
@@ -288,12 +276,11 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Try to request a new loan with the old PIN
     expect(() => {
       simulator.requestLoan(100n, oldPin);
-    }).toThrow("PIN migration is in progress for this user");
+    }).toThrow('PIN migration is in progress for this user');
   });
 
-  it("migrates loans to a new PIN that already has loans", () => {
+  it('migrates loans to a new PIN that already has loans', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const oldPin = 1234n;
     const newPin = 9876n;
 
@@ -310,7 +297,9 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Create 3 loans for the new PIN - need attestation for new pin
     const newPinPubKeyHash = simulator.computeUserPubKeyHash(simulator.userSecretKey, newPin);
     simulator.circuitContext.currentPrivateState = createCustomSignedProfile(
-      800n, 3000n, 30n,
+      800n,
+      3000n,
+      30n,
       simulator.providerSk,
       newPinPubKeyHash,
       simulator.providerId,
@@ -349,20 +338,20 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
   // Input Validation
   // ============================================================
 
-  it("throws when requesting loan with zero amount", () => {
+  it('throws when requesting loan with zero amount', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const userPin = 1234n;
 
     expect(() => {
       simulator.requestLoan(0n, userPin);
-    }).toThrow("Loan amount must be greater than zero");
+    }).toThrow('Loan amount must be greater than zero');
   });
 
   // ============================================================
   // changePin Validation
   // ============================================================
 
-  it("throws when blacklisted user tries to change PIN", () => {
+  it('throws when blacklisted user tries to change PIN', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const oldPin = 1234n;
     const newPin = 5678n;
@@ -378,10 +367,10 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Try to change PIN - should fail
     expect(() => {
       simulator.changePin(oldPin, newPin);
-    }).toThrow("User is blacklisted");
+    }).toThrow('User is blacklisted');
   });
 
-  it("throws when changing PIN to the same value", () => {
+  it('throws when changing PIN to the same value', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const userPin = 1234n;
 
@@ -391,14 +380,14 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Try to change PIN to the same value - should fail
     expect(() => {
       simulator.changePin(userPin, userPin);
-    }).toThrow("New PIN must be different from old PIN");
+    }).toThrow('New PIN must be different from old PIN');
   });
 
   // ============================================================
   // Admin Rotation
   // ============================================================
 
-  it("allows admin to rotate admin role to a new derived public key", () => {
+  it('allows admin to rotate admin role to a new derived public key', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const newAdminSecret = simulator.generateUserSecret();
     const newAdminPublicKey = simulator.deriveAdminPublicKey(newAdminSecret);
@@ -413,9 +402,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
   // Tier Boundary Edge Cases
   // ============================================================
 
-  it("approves exactly at Tier 1 boundary when amount within limit (score=700, income=2000, tenure=24)", () => {
+  it('approves exactly at Tier 1 boundary when amount within limit (score=700, income=2000, tenure=24)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 700n, 2000n, 24n, userPin);
@@ -428,9 +416,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(10000n); // Tier 1 max
   });
 
-  it("proposes Tier 2 when just below Tier 1 threshold (score=699)", () => {
+  it('proposes Tier 2 when just below Tier 1 threshold (score=699)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 699n, 2000n, 24n, userPin);
@@ -443,9 +430,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(7000n); // Falls to Tier 2 max
   });
 
-  it("proposes at Tier 2 boundary when amount exceeds limit (score=600, income=1500)", () => {
+  it('proposes at Tier 2 boundary when amount exceeds limit (score=600, income=1500)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 600n, 1500n, 1n, userPin);
@@ -458,9 +444,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(7000n); // Tier 2 max
   });
 
-  it("proposes Tier 3 when just below Tier 2 threshold (score=599)", () => {
+  it('proposes Tier 3 when just below Tier 2 threshold (score=599)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 599n, 1500n, 1n, userPin);
@@ -473,9 +458,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(3000n); // Falls to Tier 3 max
   });
 
-  it("proposes at Tier 3 boundary when amount exceeds limit (score=580)", () => {
+  it('proposes at Tier 3 boundary when amount exceeds limit (score=580)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 580n, 500n, 1n, userPin);
@@ -488,9 +472,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(3000n); // Tier 3 max
   });
 
-  it("rejects when just below Tier 3 threshold (score=579)", () => {
+  it('rejects when just below Tier 3 threshold (score=579)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 579n, 5000n, 100n, userPin);
@@ -503,9 +486,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(0n);
   });
 
-  it("proposes Tier 2 when Tier 1 income requirement not met", () => {
+  it('proposes Tier 2 when Tier 1 income requirement not met', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 1999n, 30n, userPin);
@@ -518,9 +500,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(7000n); // Falls to Tier 2
   });
 
-  it("proposes Tier 2 when Tier 1 tenure requirement not met", () => {
+  it('proposes Tier 2 when Tier 1 tenure requirement not met', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 23n, userPin);
@@ -537,9 +518,9 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
   // Admin Authorization
   // ============================================================
 
-  it("throws when non-admin tries to blacklist a user", () => {
+  it('throws when non-admin tries to blacklist a user', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const charlieZwapKey = simulator.createTestUser("Charlie").left.bytes;
+    const charlieZwapKey = simulator.createTestUser('Charlie').left.bytes;
 
     // Rotate admin to a fresh secret the simulator does not hold. The
     // simulator's private state still carries the original admin secret,
@@ -549,12 +530,12 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     expect(() => {
       simulator.blacklistUser(charlieZwapKey);
-    }).toThrow("Only admin can blacklist users");
+    }).toThrow('Only admin can blacklist users');
   });
 
-  it("throws when non-admin tries to remove from blacklist", () => {
+  it('throws when non-admin tries to remove from blacklist', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const charlieZwapKey = simulator.createTestUser("Charlie").left.bytes;
+    const charlieZwapKey = simulator.createTestUser('Charlie').left.bytes;
 
     // First blacklist Charlie while the simulator still holds the admin secret
     simulator.blacklistUser(charlieZwapKey);
@@ -565,10 +546,10 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     expect(() => {
       simulator.removeBlacklistUser(charlieZwapKey);
-    }).toThrow("Only admin can remove from blacklist");
+    }).toThrow('Only admin can remove from blacklist');
   });
 
-  it("throws when non-admin tries to rotate admin", () => {
+  it('throws when non-admin tries to rotate admin', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
 
     // Rotate admin to a fresh secret the simulator does not hold
@@ -579,16 +560,15 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     const charlieAdminSecret = simulator.generateUserSecret();
     expect(() => {
       simulator.rotateAdmin(simulator.deriveAdminPublicKey(charlieAdminSecret));
-    }).toThrow("Only admin can rotate admin role");
+    }).toThrow('Only admin can rotate admin role');
   });
 
   // ============================================================
   // Public Key Determinism
   // ============================================================
 
-  it("generates same public key for same user and PIN (determinism)", () => {
+  it('generates same public key for same user and PIN (determinism)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     const pubKey1 = simulator.deriveUserPublicKey(simulator.userSecretKey, userPin);
@@ -597,9 +577,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(pubKey1).toEqual(pubKey2);
   });
 
-  it("generates different public key for same user with different PIN", () => {
+  it('generates different public key for same user with different PIN', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const pin1 = 1234n;
     const pin2 = 5678n;
 
@@ -609,7 +588,7 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(pubKey1).not.toEqual(pubKey2);
   });
 
-  it("generates different public key for different users with same PIN", () => {
+  it('generates different public key for different users with same PIN', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const samePin = 1234n;
 
@@ -627,9 +606,9 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
   // Blacklist Edge Cases
   // ============================================================
 
-  it("blacklisting an already blacklisted user is idempotent", () => {
+  it('blacklisting an already blacklisted user is idempotent', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const bobZwapKey = simulator.createTestUser("Bob").left.bytes;
+    const bobZwapKey = simulator.createTestUser('Bob').left.bytes;
 
     // Blacklist Bob
     simulator.blacklistUser(bobZwapKey);
@@ -642,9 +621,9 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(ledger.blacklist.member({ bytes: bobZwapKey })).toBeTruthy();
   });
 
-  it("removing a non-blacklisted user from blacklist does not throw", () => {
+  it('removing a non-blacklisted user from blacklist does not throw', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const bobZwapKey = simulator.createTestUser("Bob").left.bytes;
+    const bobZwapKey = simulator.createTestUser('Bob').left.bytes;
 
     // Bob is not blacklisted
     let ledger = simulator.getLedger();
@@ -660,16 +639,20 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
   // Multi-User Isolation
   // ============================================================
 
-  it("same user with different PINs has separate loan records", () => {
+  it('same user with different PINs has separate loan records', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const aliceZwapKey = simulator.createTestUser("Alice").left.bytes;
     const pin1 = 1111n;
     const pin2 = 2222n;
 
     // Sign for pin1
     const pubKeyHash1 = simulator.computeUserPubKeyHash(simulator.userSecretKey, pin1);
     simulator.circuitContext.currentPrivateState = createCustomSignedProfile(
-      750n, 2500n, 30n, simulator.providerSk, pubKeyHash1, simulator.providerId,
+      750n,
+      2500n,
+      30n,
+      simulator.providerSk,
+      pubKeyHash1,
+      simulator.providerId,
       simulator.userSecretKey,
     );
 
@@ -682,7 +665,12 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Sign for pin2
     const pubKeyHash2 = simulator.computeUserPubKeyHash(simulator.userSecretKey, pin2);
     simulator.circuitContext.currentPrivateState = createCustomSignedProfile(
-      750n, 2500n, 30n, simulator.providerSk, pubKeyHash2, simulator.providerId,
+      750n,
+      2500n,
+      30n,
+      simulator.providerSk,
+      pubKeyHash2,
+      simulator.providerId,
       simulator.userSecretKey,
     );
 
@@ -698,10 +686,9 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(ledger.loans.lookup(pubKey2).lookup(1n).authorizedAmount).toEqual(3000n);
   });
 
-  it("blacklisting a different Zswap key does not affect the caller", () => {
+  it('blacklisting a different Zswap key does not affect the caller', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const aliceZwapKey = simulator.createTestUser("Alice").left.bytes;
-    const bobZwapKey = simulator.createTestUser("Bob").left.bytes;
+    const bobZwapKey = simulator.createTestUser('Bob').left.bytes;
     const alicePin = 1234n;
 
     const alicePubKey = simulator.deriveUserPublicKey(simulator.userSecretKey, alicePin);
@@ -721,9 +708,9 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
   // Admin Transfer Edge Cases
   // ============================================================
 
-  it("new admin can perform admin operations after rotation", () => {
+  it('new admin can perform admin operations after rotation', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const charlieZwapKey = simulator.createTestUser("Charlie").left.bytes;
+    const charlieZwapKey = simulator.createTestUser('Charlie').left.bytes;
 
     // Rotate to a new admin secret, then swap the simulator's local secret
     // to that of the new admin. The new admin now passes the auth check.
@@ -739,9 +726,9 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(ledger.blacklist.member({ bytes: charlieZwapKey })).toBeTruthy();
   });
 
-  it("old admin cannot perform admin operations after rotation", () => {
+  it('old admin cannot perform admin operations after rotation', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const charlieZwapKey = simulator.createTestUser("Charlie").left.bytes;
+    const charlieZwapKey = simulator.createTestUser('Charlie').left.bytes;
 
     // Rotate to a fresh secret the simulator does not hold
     const bobAdminSecret = simulator.generateUserSecret();
@@ -750,16 +737,14 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Original holder tries to blacklist Charlie - should fail
     expect(() => {
       simulator.blacklistUser(charlieZwapKey);
-    }).toThrow("Only admin can blacklist users");
+    }).toThrow('Only admin can blacklist users');
   });
 
-  it("can chain multiple admin rotations", () => {
+  it('can chain multiple admin rotations', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
 
     let ledger = simulator.getLedger();
-    expect(ledger.contractAdmin.bytes).toEqual(
-      simulator.deriveAdminPublicKey(simulator.userSecretKey),
-    );
+    expect(ledger.contractAdmin.bytes).toEqual(simulator.deriveAdminPublicKey(simulator.userSecretKey));
 
     // Rotate to Bob
     const bobAdminSecret = simulator.generateUserSecret();
@@ -773,9 +758,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
   // Proposed/NotAccepted Loan Flow
   // ============================================================
 
-  it("creates Proposed loan when requested amount exceeds tier limit", () => {
+  it('creates Proposed loan when requested amount exceeds tier limit', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
@@ -790,9 +774,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(10000n); // Capped at Tier 1 max
   });
 
-  it("creates Approved loan when requested amount is within tier limit", () => {
+  it('creates Approved loan when requested amount is within tier limit', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
@@ -807,9 +790,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(10000n);
   });
 
-  it("creates Approved loan when requested amount is less than tier limit", () => {
+  it('creates Approved loan when requested amount is less than tier limit', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
@@ -824,9 +806,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(5000n);
   });
 
-  it("respondToLoan with accept=true changes Proposed to Approved", () => {
+  it('respondToLoan with accept=true changes Proposed to Approved', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
@@ -846,9 +827,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(10000n); // Amount preserved
   });
 
-  it("respondToLoan with accept=false changes Proposed to NotAccepted with zero amount", () => {
+  it('respondToLoan with accept=false changes Proposed to NotAccepted with zero amount', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
@@ -868,9 +848,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(0n); // Amount set to zero
   });
 
-  it("throws when respondToLoan is called on non-Proposed loan", () => {
+  it('throws when respondToLoan is called on non-Proposed loan', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
@@ -885,17 +864,14 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Try to respond to an Approved loan - should fail
     expect(() => {
       simulator.respondToLoan(1n, userPin, true);
-    }).toThrow("Loan is not in Proposed status");
+    }).toThrow('Loan is not in Proposed status');
   });
 
-  it("throws when respondToLoan is called on already accepted loan", () => {
+  it('throws when respondToLoan is called on already accepted loan', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
-
-    const userPubKey = simulator.deriveUserPublicKey(simulator.userSecretKey, userPin);
 
     // Create and accept a Proposed loan
     simulator.requestLoan(15000n, userPin);
@@ -904,12 +880,11 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Try to respond again - should fail
     expect(() => {
       simulator.respondToLoan(1n, userPin, false);
-    }).toThrow("Loan is not in Proposed status");
+    }).toThrow('Loan is not in Proposed status');
   });
 
-  it("throws when respondToLoan is called with non-existent loan ID", () => {
+  it('throws when respondToLoan is called with non-existent loan ID', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
@@ -920,10 +895,10 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Try to respond to non-existent loan
     expect(() => {
       simulator.respondToLoan(999n, userPin, true);
-    }).toThrow("Loan not found");
+    }).toThrow('Loan not found');
   });
 
-  it("throws when respondToLoan is called by user with no loans", () => {
+  it('throws when respondToLoan is called by user with no loans', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const userPin = 1234n;
 
@@ -931,10 +906,10 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     expect(() => {
       simulator.respondToLoan(1n, userPin, true);
-    }).toThrow("No loans found for this user");
+    }).toThrow('No loans found for this user');
   });
 
-  it("throws when blacklisted user tries to respondToLoan", () => {
+  it('throws when blacklisted user tries to respondToLoan', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const userPin = 1234n;
 
@@ -950,12 +925,11 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Try to respond - should fail
     expect(() => {
       simulator.respondToLoan(1n, userPin, true);
-    }).toThrow("User is blacklisted");
+    }).toThrow('User is blacklisted');
   });
 
-  it("creates Proposed loan for Tier 2 user exceeding limit", () => {
+  it('creates Proposed loan for Tier 2 user exceeding limit', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 650n, 1600n, 10n, userPin);
@@ -970,9 +944,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(7000n); // Capped at Tier 2 max
   });
 
-  it("creates Proposed loan for Tier 3 user exceeding limit", () => {
+  it('creates Proposed loan for Tier 3 user exceeding limit', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 590n, 1000n, 1n, userPin);
@@ -987,9 +960,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(3000n); // Capped at Tier 3 max
   });
 
-  it("rejected applicant still gets Rejected status (not Proposed)", () => {
+  it('rejected applicant still gets Rejected status (not Proposed)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 500n, 1000n, 1n, userPin);
@@ -1002,9 +974,8 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(loan.authorizedAmount).toEqual(0n);
   });
 
-  it("can have multiple Proposed loans and respond to each independently", () => {
+  it('can have multiple Proposed loans and respond to each independently', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     setAttestedPrivateState(simulator, 750n, 2500n, 30n, userPin);
@@ -1014,7 +985,7 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Create multiple Proposed loans
     simulator.requestLoan(15000n, userPin); // Loan 1 - Proposed
     simulator.requestLoan(12000n, userPin); // Loan 2 - Proposed
-    simulator.requestLoan(5000n, userPin);  // Loan 3 - Approved (within limit)
+    simulator.requestLoan(5000n, userPin); // Loan 3 - Approved (within limit)
 
     let ledger = simulator.getLedger();
     expect(ledger.loans.lookup(userPubKey).lookup(1n).status).toEqual(2); // Proposed
@@ -1038,15 +1009,19 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
   // NEW TESTS: Attestation & Provider Management
   // ============================================================
 
-  it("rejects loan with invalid attestation signature", () => {
+  it('rejects loan with invalid attestation signature', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     // Create a state with a tampered signature (wrong response)
     const pubKeyHash = simulator.computeUserPubKeyHash(simulator.userSecretKey, userPin);
     const validState = createCustomSignedProfile(
-      750n, 2500n, 30n, simulator.providerSk, pubKeyHash, simulator.providerId,
+      750n,
+      2500n,
+      30n,
+      simulator.providerSk,
+      pubKeyHash,
+      simulator.providerId,
       simulator.userSecretKey,
     );
     simulator.circuitContext.currentPrivateState = {
@@ -1059,30 +1034,33 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     expect(() => {
       simulator.requestLoan(5000n, userPin);
-    }).toThrow("Invalid attestation signature");
+    }).toThrow('Invalid attestation signature');
   });
 
-  it("rejects loan with unregistered provider", () => {
+  it('rejects loan with unregistered provider', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     // Generate a different provider key pair (not registered)
     const otherProvider = generateProviderKeyPair();
     const pubKeyHash = simulator.computeUserPubKeyHash(simulator.userSecretKey, userPin);
     simulator.circuitContext.currentPrivateState = createCustomSignedProfile(
-      750n, 2500n, 30n, otherProvider.sk, pubKeyHash, 99n, // unregistered provider ID
+      750n,
+      2500n,
+      30n,
+      otherProvider.sk,
+      pubKeyHash,
+      99n, // unregistered provider ID
       simulator.userSecretKey,
     );
 
     expect(() => {
       simulator.requestLoan(5000n, userPin);
-    }).toThrow("Attestation provider not registered");
+    }).toThrow('Attestation provider not registered');
   });
 
-  it("rejects loan after provider is removed", () => {
+  it('rejects loan after provider is removed', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     // First verify the provider is registered and a loan works
@@ -1094,10 +1072,10 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     // Try to request another loan - should fail
     expect(() => {
       simulator.requestLoan(200n, userPin);
-    }).toThrow("Attestation provider not registered");
+    }).toThrow('Attestation provider not registered');
   });
 
-  it("user binding prevents replay (signature for user A cannot be used by user B)", () => {
+  it('user binding prevents replay (signature for user A cannot be used by user B)', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
     const userPin = 1234n;
 
@@ -1109,16 +1087,21 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     const otherUserSecret = simulator.generateUserSecret();
     const otherPubKeyHash = simulator.computeUserPubKeyHash(otherUserSecret, userPin);
     simulator.circuitContext.currentPrivateState = createCustomSignedProfile(
-      750n, 2500n, 30n, simulator.providerSk, otherPubKeyHash, simulator.providerId,
+      750n,
+      2500n,
+      30n,
+      simulator.providerSk,
+      otherPubKeyHash,
+      simulator.providerId,
       simulator.userSecretKey,
     );
 
     expect(() => {
       simulator.requestLoan(5000n, userPin);
-    }).toThrow("Invalid attestation signature");
+    }).toThrow('Invalid attestation signature');
   });
 
-  it("throws when non-admin tries to register provider", () => {
+  it('throws when non-admin tries to register provider', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
 
     // Rotate admin to a fresh secret the simulator does not hold
@@ -1129,10 +1112,10 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     expect(() => {
       simulator.registerProvider(2n, newProvider.pk);
-    }).toThrow("Only admin can register providers");
+    }).toThrow('Only admin can register providers');
   });
 
-  it("throws when non-admin tries to remove provider", () => {
+  it('throws when non-admin tries to remove provider', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
 
     // Rotate admin to a fresh secret the simulator does not hold
@@ -1141,20 +1124,19 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     expect(() => {
       simulator.removeProvider(simulator.providerId);
-    }).toThrow("Only admin can remove providers");
+    }).toThrow('Only admin can remove providers');
   });
 
-  it("throws when removing a non-existent provider", () => {
+  it('throws when removing a non-existent provider', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
 
     expect(() => {
       simulator.removeProvider(999n);
-    }).toThrow("Provider not found");
+    }).toThrow('Provider not found');
   });
 
-  it("multiple providers can both be used for attestation", () => {
+  it('multiple providers can both be used for attestation', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     // Register a second provider
@@ -1170,7 +1152,12 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     // Use provider 2 for second loan
     simulator.circuitContext.currentPrivateState = createCustomSignedProfile(
-      750n, 2500n, 30n, provider2.sk, pubKeyHash, provider2Id,
+      750n,
+      2500n,
+      30n,
+      provider2.sk,
+      pubKeyHash,
+      provider2Id,
       simulator.userSecretKey,
     );
     simulator.requestLoan(3000n, userPin);
@@ -1181,7 +1168,7 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(userLoans.lookup(2n).authorizedAmount).toEqual(3000n);
   });
 
-  it("provider registry shows up in ledger state", () => {
+  it('provider registry shows up in ledger state', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
 
     // Default provider should be registered
@@ -1192,15 +1179,19 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
     expect(providerPk.y).toEqual(simulator.providerPk.y);
   });
 
-  it("attestation with tampered credit data fails signature verification", () => {
+  it('attestation with tampered credit data fails signature verification', () => {
     const simulator = new ZKLoanCreditScorerSimulator();
-    const userZwapKey = simulator.createTestUser("Alice").left.bytes;
     const userPin = 1234n;
 
     // Create valid attestation
     const pubKeyHash = simulator.computeUserPubKeyHash(simulator.userSecretKey, userPin);
     const validState = createCustomSignedProfile(
-      650n, 1600n, 10n, simulator.providerSk, pubKeyHash, simulator.providerId,
+      650n,
+      1600n,
+      10n,
+      simulator.providerSk,
+      pubKeyHash,
+      simulator.providerId,
       simulator.userSecretKey,
     );
 
@@ -1212,6 +1203,6 @@ it("migrates a small number of loans (1 batch) and cleans up", () => {
 
     expect(() => {
       simulator.requestLoan(5000n, userPin);
-    }).toThrow("Invalid attestation signature");
+    }).toThrow('Invalid attestation signature');
   });
 });

--- a/contract/src/witnesses.ts
+++ b/contract/src/witnesses.ts
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Ledger } from "./managed/zkloan-credit-scorer/contract/index.js";
-import { WitnessContext } from "@midnight-ntwrk/compact-runtime";
+import { Ledger } from './managed/zkloan-credit-scorer/contract/index.js';
+import { WitnessContext } from '@midnight-ntwrk/compact-runtime';
 
 export type SchnorrSignature = {
   announcement: { x: bigint; y: bigint };
@@ -42,14 +42,10 @@ const TWO_248 = 4523128485832663883733241601901871400518358776001584532791311875
 
 export const witnesses = {
   getAttestedScoringWitness: ({
-    privateState
+    privateState,
   }: WitnessContext<Ledger, ZKLoanCreditScorerPrivateState>): [
     ZKLoanCreditScorerPrivateState,
-    [
-      { creditScore: bigint; monthlyIncome: bigint; monthsAsCustomer: bigint },
-      SchnorrSignature,
-      bigint,
-    ],
+    [{ creditScore: bigint; monthlyIncome: bigint; monthsAsCustomer: bigint }, SchnorrSignature, bigint],
   ] => [
     privateState,
     [
@@ -63,9 +59,8 @@ export const witnesses = {
     ],
   ],
 
-  getSchnorrReduction: ({
-    privateState
-  }: WitnessContext<Ledger, ZKLoanCreditScorerPrivateState>,
+  getSchnorrReduction: (
+    { privateState }: WitnessContext<Ledger, ZKLoanCreditScorerPrivateState>,
     challengeHash: bigint,
   ): [ZKLoanCreditScorerPrivateState, [bigint, bigint]] => {
     const q = challengeHash / TWO_248;
@@ -74,13 +69,13 @@ export const witnesses = {
   },
 
   getUserSecret: ({
-    privateState
+    privateState,
   }: WitnessContext<Ledger, ZKLoanCreditScorerPrivateState>): [
     ZKLoanCreditScorerPrivateState,
     { bytes: Uint8Array },
   ] => {
     if (!privateState.userSecretKey || privateState.userSecretKey.length !== 32) {
-      throw new Error("getUserSecret: userSecretKey is missing or wrong length");
+      throw new Error('getUserSecret: userSecretKey is missing or wrong length');
     }
     return [privateState, { bytes: privateState.userSecretKey }];
   },

--- a/zkloan-credit-scorer-cli/eslint.config.mjs
+++ b/zkloan-credit-scorer-cli/eslint.config.mjs
@@ -34,6 +34,7 @@ export default [
         Buffer: 'readonly',
         URL: 'readonly',
         setTimeout: 'readonly',
+        fetch: 'readonly',
       },
     },
     plugins: {

--- a/zkloan-credit-scorer-cli/src/address-utils.ts
+++ b/zkloan-credit-scorer-cli/src/address-utils.ts
@@ -13,10 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  MidnightBech32m,
-  ShieldedAddress,
-} from '@midnight-ntwrk/wallet-sdk-address-format';
+import { MidnightBech32m, ShieldedAddress } from '@midnight-ntwrk/wallet-sdk-address-format';
 import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 
 /**
@@ -59,8 +56,8 @@ export function resolveZswapCoinPublicKey(input: string): Uint8Array {
     } catch (err) {
       throw new Error(
         `Could not decode shielded address for network '${String(networkId)}'. ` +
-        `Ensure the address prefix matches the active network. ` +
-        `Cause: ${err instanceof Error ? err.message : String(err)}`,
+          `Ensure the address prefix matches the active network. ` +
+          `Cause: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
@@ -69,14 +66,11 @@ export function resolveZswapCoinPublicKey(input: string): Uint8Array {
   const hex = value.toLowerCase().replace(/^0x/, '');
   if (!/^[0-9a-f]+$/.test(hex)) {
     throw new Error(
-      'Unrecognised address format. Expected a shielded address (mn_shield-addr_…) ' +
-      'or a 32-byte hex string.',
+      'Unrecognised address format. Expected a shielded address (mn_shield-addr_…) ' + 'or a 32-byte hex string.',
     );
   }
   if (hex.length !== 64) {
-    throw new Error(
-      `Hex public key must be exactly 64 hex chars (32 bytes); got ${hex.length}.`,
-    );
+    throw new Error(`Hex public key must be exactly 64 hex chars (32 bytes); got ${hex.length}.`);
   }
   return Uint8Array.from(Buffer.from(hex, 'hex'));
 }

--- a/zkloan-credit-scorer-cli/src/api.ts
+++ b/zkloan-credit-scorer-cli/src/api.ts
@@ -89,11 +89,8 @@ export const getZKLoanLedgerState = async (
 // Create compiled contract using the stable API pattern
 export const zkLoanCompiledContract = CompiledContract.make<ZKLoanCreditScorerContract>(
   'ZKLoanCreditScorer',
-  ZKLoanCreditScorer.Contract
-).pipe(
-  CompiledContract.withWitnesses(witnesses),
-  CompiledContract.withCompiledFileAssets(contractConfig.zkConfigPath),
-);
+  ZKLoanCreditScorer.Contract,
+).pipe(CompiledContract.withWitnesses(witnesses), CompiledContract.withCompiledFileAssets(contractConfig.zkConfigPath));
 
 export const joinContract = async (
   providers: ZKLoanCreditScorerProviders,
@@ -168,7 +165,7 @@ export const fetchAttestation = async (
   if (!res.ok) {
     throw new Error(`Attestation API error: ${res.status} ${await res.text()}`);
   }
-  const data = await res.json() as { signature: { announcement: { x: string; y: string }; response: string } };
+  const data = (await res.json()) as { signature: { announcement: { x: string; y: string }; response: string } };
   return {
     announcement: { x: BigInt(data.signature.announcement.x), y: BigInt(data.signature.announcement.y) },
     response: BigInt(data.signature.response),
@@ -204,7 +201,7 @@ export const requestLoan = async (
 
   // 4. Get provider info
   const providerRes = await fetch(`${attestationApiUrl}/provider-info`);
-  const providerInfo = await providerRes.json() as { providerId: number };
+  const providerInfo = (await providerRes.json()) as { providerId: number };
 
   // 5. Update private state with attestation data
   const updatedState: ZKLoanCreditScorerPrivateState = {
@@ -327,9 +324,7 @@ export const createWalletAndMidnightProvider = async (
   walletContext: WalletContext,
 ): Promise<WalletProvider & MidnightProvider> => {
   // Wait for wallet to sync first
-  await Rx.firstValueFrom(
-    walletContext.wallet.state().pipe(Rx.filter((s) => s.isSynced)),
-  );
+  await Rx.firstValueFrom(walletContext.wallet.state().pipe(Rx.filter((s) => s.isSynced)));
 
   return {
     getCoinPublicKey(): ledger.CoinPublicKey {
@@ -340,10 +335,7 @@ export const createWalletAndMidnightProvider = async (
       return walletContext.shieldedSecretKeys.encryptionPublicKey;
     },
 
-    async balanceTx(
-      tx: UnboundTransaction,
-      ttl?: Date,
-    ): Promise<ledger.FinalizedTransaction> {
+    async balanceTx(tx: UnboundTransaction, ttl?: Date): Promise<ledger.FinalizedTransaction> {
       const txTtl = ttl ?? new Date(Date.now() + 30 * 60 * 1000); // 30 min default TTL
 
       // Use the wallet facade to balance the unbound (proven) transaction
@@ -385,10 +377,16 @@ export const waitForFunds = (wallet: WalletFacade) =>
       Rx.tap((state) => {
         const unshielded = state.unshielded?.balances[ledger.nativeToken().raw] ?? 0n;
         const shielded = state.shielded?.balances[ledger.nativeToken().raw] ?? 0n;
-        logger.info(`Waiting for NIGHT funds. Synced: ${state.isSynced}, Unshielded: ${unshielded}, Shielded: ${shielded}`);
+        logger.info(
+          `Waiting for NIGHT funds. Synced: ${state.isSynced}, Unshielded: ${unshielded}, Shielded: ${shielded}`,
+        );
       }),
       Rx.filter((state) => state.isSynced),
-      Rx.map((s) => (s.unshielded?.balances[ledger.nativeToken().raw] ?? 0n) + (s.shielded?.balances[ledger.nativeToken().raw] ?? 0n)),
+      Rx.map(
+        (s) =>
+          (s.unshielded?.balances[ledger.nativeToken().raw] ?? 0n) +
+          (s.shielded?.balances[ledger.nativeToken().raw] ?? 0n),
+      ),
       Rx.filter((balance) => balance > 0n),
     ),
   );
@@ -401,7 +399,9 @@ export const waitForFunds = (wallet: WalletFacade) =>
  * tNIGHT / tDUST variants. We query the native token for NIGHT and the
  * dust wallet for DUST and surface both so it's obvious which is which.
  */
-export const displayWalletBalances = async (wallet: WalletFacade): Promise<{ unshielded: bigint; shielded: bigint; total: bigint; dust: bigint }> => {
+export const displayWalletBalances = async (
+  wallet: WalletFacade,
+): Promise<{ unshielded: bigint; shielded: bigint; total: bigint; dust: bigint }> => {
   const state = await Rx.firstValueFrom(wallet.state());
   const unshielded = state.unshielded?.balances[ledger.nativeToken().raw] ?? 0n;
   const shielded = state.shielded?.balances[ledger.nativeToken().raw] ?? 0n;
@@ -424,9 +424,8 @@ export const registerNightForDust = async (walletContext: WalletContext): Promis
   const state = await Rx.firstValueFrom(walletContext.wallet.state().pipe(Rx.filter((s) => s.isSynced)));
 
   // Check if we have unshielded coins that are not registered for dust generation
-  const unregisteredNightUtxos = state.unshielded?.availableCoins.filter(
-    (coin) => coin.meta.registeredForDustGeneration === false
-  ) ?? [];
+  const unregisteredNightUtxos =
+    state.unshielded?.availableCoins.filter((coin) => coin.meta.registeredForDustGeneration === false) ?? [];
 
   if (unregisteredNightUtxos.length === 0) {
     logger.info('No unshielded Night UTXOs available for dust registration, or all are already registered');
@@ -493,10 +492,7 @@ export const mnemonicToSeed = async (mnemonic: string): Promise<Buffer> => {
 /**
  * Initialize wallet with seed using the new wallet SDK
  */
-export const initWalletWithSeed = async (
-  seed: Buffer,
-  config: Config,
-): Promise<WalletContext> => {
+export const initWalletWithSeed = async (seed: Buffer, config: Config): Promise<WalletContext> => {
   const hdWallet = HDWallet.fromSeed(seed);
 
   if (hdWallet.type !== 'seedOk') {
@@ -565,13 +561,10 @@ export const initWalletWithSeed = async (
   const facade = await WalletFacade.init({
     configuration: unifiedConfig,
     shielded: () => ShieldedWallet(shieldedConfig).startWithSecretKeys(shieldedSecretKeys),
-    unshielded: () => UnshieldedWallet(unshieldedConfig).startWithPublicKey(
-      UnshieldedPublicKey.fromKeyStore(unshieldedKeystore),
-    ),
-    dust: () => DustWallet(dustConfig).startWithSecretKey(
-      dustSecretKey,
-      ledger.LedgerParameters.initialParameters().dust,
-    ),
+    unshielded: () =>
+      UnshieldedWallet(unshieldedConfig).startWithPublicKey(UnshieldedPublicKey.fromKeyStore(unshieldedKeystore)),
+    dust: () =>
+      DustWallet(dustConfig).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
   });
   await facade.start(shieldedSecretKeys, dustSecretKey);
 
@@ -581,10 +574,7 @@ export const initWalletWithSeed = async (
 /**
  * Build wallet from mnemonic and wait for funds
  */
-export const buildWalletAndWaitForFunds = async (
-  config: Config,
-  mnemonic: string,
-): Promise<WalletContext> => {
+export const buildWalletAndWaitForFunds = async (config: Config, mnemonic: string): Promise<WalletContext> => {
   logger.info('Building wallet from mnemonic...');
 
   const seed = await mnemonicToSeed(mnemonic);
@@ -629,10 +619,7 @@ export const buildFreshWallet = async (config: Config): Promise<WalletContext> =
 /**
  * Build wallet from hex seed (for backwards compatibility with genesis wallet)
  */
-export const buildWalletFromHexSeed = async (
-  config: Config,
-  hexSeed: string,
-): Promise<WalletContext> => {
+export const buildWalletFromHexSeed = async (config: Config, hexSeed: string): Promise<WalletContext> => {
   logger.info('Building wallet from hex seed...');
   const seed = Buffer.from(hexSeed, 'hex');
   const walletContext = await initWalletWithSeed(seed, config);
@@ -658,7 +645,10 @@ export const buildWalletFromHexSeed = async (
   return walletContext;
 };
 
-export const configureProviders = async (walletContext: WalletContext, config: Config): Promise<ZKLoanCreditScorerProviders> => {
+export const configureProviders = async (
+  walletContext: WalletContext,
+  config: Config,
+): Promise<ZKLoanCreditScorerProviders> => {
   // Set global network ID - required before contract deployment
   setNetworkId(config.networkId);
 
@@ -668,7 +658,7 @@ export const configureProviders = async (walletContext: WalletContext, config: C
   if (!storagePassword) {
     throw new Error(
       'MIDNIGHT_STORAGE_PASSWORD is not set. Set it in zkloan-credit-scorer-cli/.env (see .env.example). ' +
-      'The level-private-state-provider requires it to encrypt private state on disk.'
+        'The level-private-state-provider requires it to encrypt private state on disk.',
     );
   }
 

--- a/zkloan-credit-scorer-cli/src/cli.ts
+++ b/zkloan-credit-scorer-cli/src/cli.ts
@@ -53,12 +53,18 @@ You can do one of the following:
   10. Exit
 Which would you like to do? `;
 
-const join = async (providers: ZKLoanCreditScorerProviders, rli: Interface): Promise<DeployedZKLoanCreditScorerContract> => {
+const join = async (
+  providers: ZKLoanCreditScorerProviders,
+  rli: Interface,
+): Promise<DeployedZKLoanCreditScorerContract> => {
   const contractAddress = await rli.question('What is the contract address (in hex)? ');
   return await api.joinContract(providers, contractAddress);
 };
 
-const deployOrJoin = async (providers: ZKLoanCreditScorerProviders, rli: Interface): Promise<DeployedZKLoanCreditScorerContract | null> => {
+const deployOrJoin = async (
+  providers: ZKLoanCreditScorerProviders,
+  rli: Interface,
+): Promise<DeployedZKLoanCreditScorerContract | null> => {
   while (true) {
     const choice = await rli.question(DEPLOY_OR_JOIN_QUESTION);
     switch (choice) {
@@ -111,7 +117,7 @@ const changePinFlow = async (contract: DeployedZKLoanCreditScorerContract, rli: 
 };
 
 const USER_PUBKEY_PROMPT_HINT =
-  '(64-char hex of the user\'s derived UserPublicKey — e.g. read from the on-chain `loans` map key, or shared by the target)';
+  "(64-char hex of the user's derived UserPublicKey — e.g. read from the on-chain `loans` map key, or shared by the target)";
 
 const parseUserPublicKeyHex = (input: string): Uint8Array => {
   const hex = input.trim().toLowerCase().replace(/^0x/, '');
@@ -140,7 +146,7 @@ const removeBlacklistUserFlow = async (contract: DeployedZKLoanCreditScorerContr
 const rotateAdminFlow = async (contract: DeployedZKLoanCreditScorerContract, rli: Interface): Promise<void> => {
   const input = await rli.question(
     'Enter the new admin derived public key (64 hex chars). ' +
-    'The new admin generates this with `deriveAdminPublicKey(userSecret)` and shares only the result: ',
+      'The new admin generates this with `deriveAdminPublicKey(userSecret)` and shares only the result: ',
   );
   const hex = input.trim().toLowerCase().replace(/^0x/, '');
   if (!/^[0-9a-f]{64}$/.test(hex)) {
@@ -170,7 +176,11 @@ const removeProviderFlow = async (contract: DeployedZKLoanCreditScorerContract, 
   logger.info('Attestation provider removed successfully!');
 };
 
-const mainLoop = async (providers: ZKLoanCreditScorerProviders, walletContext: WalletContext, rli: Interface): Promise<void> => {
+const mainLoop = async (
+  providers: ZKLoanCreditScorerProviders,
+  walletContext: WalletContext,
+  rli: Interface,
+): Promise<void> => {
   const contract = await deployOrJoin(providers, rli);
   if (contract === null) {
     return;

--- a/zkloan-credit-scorer-cli/src/common-types.ts
+++ b/zkloan-credit-scorer-cli/src/common-types.ts
@@ -17,12 +17,26 @@ import { ZKLoanCreditScorer, type ZKLoanCreditScorerPrivateState } from 'zkloan-
 import type { MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 import type { DeployedContract, FoundContract } from '@midnight-ntwrk/midnight-js-contracts';
 
-export type ZKLoanCreditScorerCircuits = 'requestLoan' | 'changePin' | 'blacklistUser' | 'removeBlacklistUser' | 'rotateAdmin' | 'respondToLoan' | 'registerProvider' | 'removeProvider';
+export type ZKLoanCreditScorerCircuits =
+  | 'requestLoan'
+  | 'changePin'
+  | 'blacklistUser'
+  | 'removeBlacklistUser'
+  | 'rotateAdmin'
+  | 'respondToLoan'
+  | 'registerProvider'
+  | 'removeProvider';
 
 export const ZKLoanCreditScorerPrivateStateId = 'zkLoanCreditScorerPrivateState';
 
-export type ZKLoanCreditScorerProviders = MidnightProviders<ZKLoanCreditScorerCircuits, typeof ZKLoanCreditScorerPrivateStateId, ZKLoanCreditScorerPrivateState>;
+export type ZKLoanCreditScorerProviders = MidnightProviders<
+  ZKLoanCreditScorerCircuits,
+  typeof ZKLoanCreditScorerPrivateStateId,
+  ZKLoanCreditScorerPrivateState
+>;
 
 export type ZKLoanCreditScorerContract = ZKLoanCreditScorer.Contract<ZKLoanCreditScorerPrivateState>;
 
-export type DeployedZKLoanCreditScorerContract = DeployedContract<ZKLoanCreditScorerContract> | FoundContract<ZKLoanCreditScorerContract>;
+export type DeployedZKLoanCreditScorerContract =
+  | DeployedContract<ZKLoanCreditScorerContract>
+  | FoundContract<ZKLoanCreditScorerContract>;

--- a/zkloan-credit-scorer-cli/src/state.utils.ts
+++ b/zkloan-credit-scorer-cli/src/state.utils.ts
@@ -18,65 +18,65 @@ function generateUserSecret(): Uint8Array {
 
 export const userProfiles = [
   {
-    "applicantId": "user-001",
-    "creditScore": 720,
-    "monthlyIncome": 2500,
-    "monthsAsCustomer": 24
+    applicantId: 'user-001',
+    creditScore: 720,
+    monthlyIncome: 2500,
+    monthsAsCustomer: 24,
   },
   {
-    "applicantId": "user-002",
-    "creditScore": 650,
-    "monthlyIncome": 1800,
-    "monthsAsCustomer": 11
+    applicantId: 'user-002',
+    creditScore: 650,
+    monthlyIncome: 1800,
+    monthsAsCustomer: 11,
   },
   {
-    "applicantId": "user-003",
-    "creditScore": 580,
-    "monthlyIncome": 2200,
-    "monthsAsCustomer": 36
+    applicantId: 'user-003',
+    creditScore: 580,
+    monthlyIncome: 2200,
+    monthsAsCustomer: 36,
   },
   {
-    "applicantId": "user-004",
-    "creditScore": 710,
-    "monthlyIncome": 1900, // Fails Tier 1 on income
-    "monthsAsCustomer": 5
+    applicantId: 'user-004',
+    creditScore: 710,
+    monthlyIncome: 1900, // Fails Tier 1 on income
+    monthsAsCustomer: 5,
   },
   {
-    "applicantId": "user-005",
-    "creditScore": 520,      // Fails all tiers
-    "monthlyIncome": 3000,
-    "monthsAsCustomer": 48
+    applicantId: 'user-005',
+    creditScore: 520, // Fails all tiers
+    monthlyIncome: 3000,
+    monthsAsCustomer: 48,
   },
   {
-    "applicantId": "user-006",
-    "creditScore": 810,
-    "monthlyIncome": 4500,
-    "monthsAsCustomer": 60
+    applicantId: 'user-006',
+    creditScore: 810,
+    monthlyIncome: 4500,
+    monthsAsCustomer: 60,
   },
   {
-    "applicantId": "user-007",
-    "creditScore": 639,      // Fails Tier 2, qualifies for Tier 3
-    "monthlyIncome": 2100,
-    "monthsAsCustomer": 18
+    applicantId: 'user-007',
+    creditScore: 639, // Fails Tier 2, qualifies for Tier 3
+    monthlyIncome: 2100,
+    monthsAsCustomer: 18,
   },
   {
-    "applicantId": "user-008",
-    "creditScore": 680,
-    "monthlyIncome": 1450, // Fails Tier 2 on income
-    "monthsAsCustomer": 30
+    applicantId: 'user-008',
+    creditScore: 680,
+    monthlyIncome: 1450, // Fails Tier 2 on income
+    monthsAsCustomer: 30,
   },
   {
-    "applicantId": "user-009",
-    "creditScore": 750,
-    "monthlyIncome": 2100,
-    "monthsAsCustomer": 23  // Fails Tier 1 on customer tenure
+    applicantId: 'user-009',
+    creditScore: 750,
+    monthlyIncome: 2100,
+    monthsAsCustomer: 23, // Fails Tier 1 on customer tenure
   },
   {
-    "applicantId": "user-010",
-    "creditScore": 579,      // Fails all tiers, just misses Tier 3
-    "monthlyIncome": 1900,
-    "monthsAsCustomer": 12
-  }
+    applicantId: 'user-010',
+    creditScore: 579, // Fails all tiers, just misses Tier 3
+    monthlyIncome: 1900,
+    monthsAsCustomer: 12,
+  },
 ];
 
 export function getUserProfile(

--- a/zkloan-credit-scorer-cli/src/test/commons.ts
+++ b/zkloan-credit-scorer-cli/src/test/commons.ts
@@ -196,15 +196,9 @@ export class TestEnvironment {
 
     // Use hex seed for standalone (genesis wallet), mnemonic for preprod
     if (this.testConfig.dappConfig instanceof StandaloneConfig) {
-      this.walletContext = await api.buildWalletFromHexSeed(
-        this.testConfig.dappConfig,
-        this.testConfig.seed,
-      );
+      this.walletContext = await api.buildWalletFromHexSeed(this.testConfig.dappConfig, this.testConfig.seed);
     } else {
-      this.walletContext = await api.buildWalletAndWaitForFunds(
-        this.testConfig.dappConfig,
-        this.testConfig.mnemonic,
-      );
+      this.walletContext = await api.buildWalletAndWaitForFunds(this.testConfig.dappConfig, this.testConfig.mnemonic);
     }
 
     expect(this.walletContext).not.toBeNull();

--- a/zkloan-credit-scorer-cli/src/test/zkloan.api.test.ts
+++ b/zkloan-credit-scorer-cli/src/test/zkloan.api.test.ts
@@ -65,13 +65,7 @@ describe('ZKLoan Credit Scorer API', () => {
 
     const attestationApiUrl = process.env.ATTESTATION_API_URL ?? 'http://localhost:4000';
 
-    const response = await api.requestLoan(
-      contract,
-      providers,
-      amountRequested,
-      secretPin,
-      attestationApiUrl,
-    );
+    const response = await api.requestLoan(contract, providers, amountRequested, secretPin, attestationApiUrl);
     expect(response.txId).toMatch(/[0-9a-f]{64}/);
     expect(response.blockHeight).toBeGreaterThan(BigInt(0));
 


### PR DESCRIPTION
## Problem

`npm run lint` fails on `main` for both the `contract` and `zkloan-credit-scorer-cli` packages, so the **install-and-test** CI job goes red before it reaches compile/typecheck/test. Fixing the lint then exposed a *second* pre-existing failure underneath: the attestation API is incompatible with the CI's Node 24. Both are pre-existing on `main` and unrelated to any feature change — stacked behind the lint step that aborted the job first.

## Fixes

**1. `contract/.prettierrc` was misconfigured** — only `{ "trailingComma": "none" }`, so prettier defaulted to double quotes / no trailing comma while the codebase uses single quotes + trailing commas. Aligned it to the sibling CLI's `.prettierrc.json` (`singleQuote`, `trailingComma: "all"`, `printWidth: 120`, `semi`) and ran `prettier --write` over both packages' `src`.

**2. eslint applied base JS `no-undef` to TypeScript**, flagging Node globals (`Buffer`, `fetch`). Added a `globals` block to `contract/eslint.config.mjs` and the missing `fetch` to the CLI's globals.

**3. Dead code in the contract tests.** Removed 39 unused `userZwapKey`/`aliceZwapKey`/`userPubKey` assignments (orphaned when caller identity moved off `ownPublicKey()`), an unused `bigintReplacer`, and unused imports.

**4. Added `contract/.prettierignore`** (`src/managed`, `dist`).

**5. Pinned CI to Node 22.** The attestation API uses **restify**, which unconditionally `require('spdy')` → `http-deceiver` → `process.binding('http_parser')` — an internal binding removed in Node 23+. On Node 24, `require('restify')` throws `No such module: http_parser` at import and `test/server.test.ts` can't load. Node 22 is the project's declared minimum engine (`>=22.0.0`) and still has the binding. (Stubbing `spdy` via the repo's `@aspect-build/empty` pattern isn't viable — that package 404s on a fresh resolve and only installs via the pinned lockfile tarball.) Proper fix is migrating off restify — follow-up.

## Scope

Formatting + config + dead-code + a one-line CI Node pin. **No source semantics changed.** `contract/src/managed` and `dist` untouched.

## Verification (Node 22)

- `contract`: `eslint src` exit 0 · `tsc --noEmit` clean · **61/61 tests**
- `cli`: `eslint src` exit 0 · `tsc --noEmit` clean
- `ui`: `tsc --noEmit` clean
- `attestation-api`: **10/10 tests** (incl. `server.test.ts`, which fails on Node 24)

> The CLI's `test-api` step is Docker-backed and not run locally; its changes here are formatting-only.

## Relation to other PRs

Independent of #33 (the `new type` identity refactor). Landing this turns CI green; #33 goes green on rebase.